### PR TITLE
Add LIDAR viewer based on python poc

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Setup Android SDK
+        run: ./scripts/setup_android_sdk.sh
+      - name: Run unit tests
+        run: ./gradlew test --no-daemon
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Developer instructions
+
+## Testing
+- Always run `./gradlew tasks --no-daemon` to verify Gradle configuration
+- Run `./gradlew test --no-daemon` and make sure tests pass before committing
+
+## Code style
+- Kotlin code uses 4 space indentation and standard idiomatic style.
+- Use Jetpack Compose for UI components.
+- Favor coroutines and flows for async operations.
+
+## Documentation
+- Place any additional docs in the `docs/` directory using AsciiDoc (`.adoc`).
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.material)
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation(libs.coroutines)
+    implementation(libs.usbserial)
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation(libs.material)
     implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation(libs.coroutines)
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.example.positioner">
+    <uses-feature android:name="android.hardware.usb.host" />
     <application
         android:label="Positioner App"
         android:theme="@style/Theme.Positioner">

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.flow.collect
 import org.example.positioner.lidar.LidarMeasurement
 import org.example.positioner.lidar.LidarPlot
 import org.example.positioner.lidar.LidarReader
+import org.example.positioner.lidar.LidarDataSource
+import org.example.positioner.lidar.FakeLidarReader
 import org.example.positioner.logging.AppLog
 import org.example.positioner.logging.LogView
 
@@ -48,13 +50,13 @@ private fun LidarScreen() {
         val buffer = mutableListOf<LidarMeasurement>()
         try {
             AppLog.d("MainActivity", "Opening LidarReader")
-            val reader = withContext(Dispatchers.IO) { LidarReader.openDefault(context) }
-            if (reader == null) {
-                AppLog.d("MainActivity", "No reader available")
-                return@produceState
-            }
+            val realReader = withContext(Dispatchers.IO) { LidarReader.openDefault(context) }
+            val source: LidarDataSource = if (realReader == null) {
+                AppLog.d("MainActivity", "Using FakeLidarReader")
+                FakeLidarReader()
+            } else realReader
             AppLog.d("MainActivity", "Starting measurement collection")
-            reader.measurements().collect { m ->
+            source.measurements().collect { m ->
                 buffer.add(m)
                 if (buffer.size >= 480) {
                     value = buffer.toList()

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -7,8 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.flow.collect
@@ -35,9 +35,11 @@ fun PositionerApp() {
 @Composable
 private fun LidarScreen() {
     val measurements by produceState(initialValue = emptyList<LidarMeasurement>()) {
+        val context = LocalContext.current
         val buffer = mutableListOf<LidarMeasurement>()
         try {
-            val reader = LidarReader.openDefault()
+            val reader = LidarReader.openDefault(context)
+            if (reader == null) return@produceState
             reader.measurements().collect { m ->
                 buffer.add(m)
                 if (buffer.size >= 480) {

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -15,6 +15,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.collect
 import org.example.positioner.lidar.LidarMeasurement
 import org.example.positioner.lidar.LidarPlot
@@ -45,8 +47,13 @@ private fun LidarScreen() {
     val measurements by produceState(initialValue = emptyList<LidarMeasurement>(), context) {
         val buffer = mutableListOf<LidarMeasurement>()
         try {
-            val reader = LidarReader.openDefault(context)
-            if (reader == null) return@produceState
+            AppLog.d("MainActivity", "Opening LidarReader")
+            val reader = withContext(Dispatchers.IO) { LidarReader.openDefault(context) }
+            if (reader == null) {
+                AppLog.d("MainActivity", "No reader available")
+                return@produceState
+            }
+            AppLog.d("MainActivity", "Starting measurement collection")
             reader.measurements().collect { m ->
                 buffer.add(m)
                 if (buffer.size >= 480) {

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -34,8 +34,8 @@ fun PositionerApp() {
 
 @Composable
 private fun LidarScreen() {
-    val measurements by produceState(initialValue = emptyList<LidarMeasurement>()) {
-        val context = LocalContext.current
+    val context = LocalContext.current
+    val measurements by produceState(initialValue = emptyList<LidarMeasurement>(), context) {
         val buffer = mutableListOf<LidarMeasurement>()
         try {
             val reader = LidarReader.openDefault(context)

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -3,11 +3,15 @@ package org.example.positioner
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -15,6 +19,8 @@ import kotlinx.coroutines.flow.collect
 import org.example.positioner.lidar.LidarMeasurement
 import org.example.positioner.lidar.LidarPlot
 import org.example.positioner.lidar.LidarReader
+import org.example.positioner.logging.AppLog
+import org.example.positioner.logging.LogView
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,6 +41,7 @@ fun PositionerApp() {
 @Composable
 private fun LidarScreen() {
     val context = LocalContext.current
+    val logs by AppLog.logs.collectAsState()
     val measurements by produceState(initialValue = emptyList<LidarMeasurement>(), context) {
         val buffer = mutableListOf<LidarMeasurement>()
         try {
@@ -51,7 +58,10 @@ private fun LidarScreen() {
             // In case opening the serial port fails just keep empty data
         }
     }
-    LidarPlot(measurements, modifier = Modifier.fillMaxSize())
+    Column(modifier = Modifier.fillMaxSize()) {
+        LidarPlot(measurements, modifier = Modifier.weight(1f))
+        LogView(logs, modifier = Modifier.height(160.dp))
+    }
 }
 
 @Preview

--- a/app/src/main/kotlin/org/example/positioner/lidar/FakeLidarReader.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/FakeLidarReader.kt
@@ -1,0 +1,24 @@
+package org.example.positioner.lidar
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlin.math.sin
+import kotlin.math.PI
+
+/**
+ * Generates fake lidar measurements for testing in the emulator.
+ */
+class FakeLidarReader : LidarDataSource {
+    override fun measurements(): Flow<LidarMeasurement> = flow {
+        var angle = 0f
+        while (true) {
+            val radiusMm = 1000 + (500 * (1 + sin(angle / 180f * PI.toFloat()))).toInt()
+            emit(LidarMeasurement(angle % 360f, radiusMm, 255))
+            angle += 2f
+            delay(20)
+        }
+    }.flowOn(Dispatchers.Default)
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
@@ -1,0 +1,25 @@
+package org.example.positioner.lidar
+
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.PI
+
+/**
+ * Single measurement from the LIDAR.
+ */
+data class LidarMeasurement(
+    val angle: Float,       // angle in degrees
+    val distanceMm: Int,    // distance in millimetres
+    val confidence: Int
+) {
+    /**
+     * Convert the polar measurement to cartesian coordinates in metres.
+     */
+    fun toPoint(): Pair<Float, Float> {
+        val r = distanceMm / 1000f
+        val rad = angle / 180f * PI.toFloat()
+        val x = sin(rad) * r
+        val y = cos(rad) * r
+        return x to y
+    }
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarDataSource.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarDataSource.kt
@@ -1,0 +1,11 @@
+package org.example.positioner.lidar
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Common interface for classes that can provide lidar measurements.
+ */
+interface LidarDataSource {
+    /** Stream of lidar measurements. */
+    fun measurements(): Flow<LidarMeasurement>
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarParser.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarParser.kt
@@ -1,0 +1,50 @@
+package org.example.positioner.lidar
+
+import android.util.Log
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Parser for packets produced by the YDLIDAR X4 and compatible devices.
+ */
+class LidarParser {
+    companion object {
+        private const val TAG = "LidarParser"
+        private const val PACKET_LENGTH = 47
+        private const val MEASUREMENT_LENGTH = 12
+    }
+
+    /**
+     * Parse a single packet. `data` must contain exactly 47 bytes starting with
+     * 0x54 and 0x2C.
+     */
+    fun parse(data: ByteArray): List<LidarMeasurement> {
+        require(data.size == PACKET_LENGTH) { "Invalid packet length" }
+        val buf = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN)
+        buf.get() // header 0x54
+        buf.get() // length 0x2C
+        buf.short // speed
+        val startAngle = (buf.short.toUShort().toFloat()) / 100f
+        val distance = IntArray(MEASUREMENT_LENGTH)
+        val confidence = IntArray(MEASUREMENT_LENGTH)
+        for (i in 0 until MEASUREMENT_LENGTH) {
+            distance[i] = buf.short.toUShort().toInt()
+            confidence[i] = buf.get().toUByte().toInt()
+        }
+        var stopAngle = (buf.short.toUShort().toFloat()) / 100f
+        buf.short // timestamp
+        buf.get()  // crc
+
+        if (stopAngle < startAngle) {
+            stopAngle += 360f
+        }
+        val step = (stopAngle - startAngle) / (MEASUREMENT_LENGTH - 1)
+        Log.d(TAG, "startAngle=${'$'}startAngle stopAngle=${'$'}stopAngle")
+        val result = mutableListOf<LidarMeasurement>()
+        for (i in 0 until MEASUREMENT_LENGTH) {
+            val angle = startAngle + step * i
+            result.add(LidarMeasurement(angle, distance[i], confidence[i]))
+        }
+        return result
+    }
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarParser.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarParser.kt
@@ -1,6 +1,6 @@
 package org.example.positioner.lidar
 
-import android.util.Log
+import org.example.positioner.logging.AppLog
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -39,7 +39,7 @@ class LidarParser {
             stopAngle += 360f
         }
         val step = (stopAngle - startAngle) / (MEASUREMENT_LENGTH - 1)
-        Log.d(TAG, "startAngle=${'$'}startAngle stopAngle=${'$'}stopAngle")
+        AppLog.d(TAG, "startAngle=${'$'}startAngle stopAngle=${'$'}stopAngle")
         val result = mutableListOf<LidarMeasurement>()
         for (i in 0 until MEASUREMENT_LENGTH) {
             val angle = startAngle + step * i

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarPlot.kt
@@ -1,0 +1,26 @@
+package org.example.positioner.lidar
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import kotlin.math.min
+
+/**
+ * Display a scatter plot of lidar measurements.
+ */
+@Composable
+fun LidarPlot(measurements: List<LidarMeasurement>, modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier) {
+        val maxRange = 4f // metres, matches python default
+        val scale = min(size.width, size.height) / (maxRange * 2f)
+        val center = Offset(size.width / 2f, size.height / 2f)
+        measurements.forEach { m ->
+            val (x, y) = m.toPoint()
+            val px = center.x + x * scale
+            val py = center.y - y * scale
+            drawCircle(Color.Red, radius = 3f, center = Offset(px, py))
+        }
+    }
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
@@ -1,0 +1,60 @@
+package org.example.positioner.lidar
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import java.io.FileInputStream
+import java.io.InputStream
+
+/**
+ * Continuously read measurement packets from the serial port and emit
+ * individual measurements as a [Flow]. The implementation searches for
+ * packet headers (0x54, 0x2C) and uses [LidarParser] to decode the packet.
+ */
+class LidarReader(private val input: InputStream) {
+    private val parser = LidarParser()
+
+    companion object {
+        private const val TAG = "LidarReader"
+
+        /**
+         * Helper to open the default serial port used by the python POC.
+         */
+        fun openDefault(): LidarReader = LidarReader(FileInputStream("/dev/ttyAMA0"))
+    }
+
+    fun measurements(): Flow<LidarMeasurement> = flow {
+        val packet = ByteArray(47)
+        val header = byteArrayOf(0x54.toByte(), 0x2C.toByte())
+        val buffer = ByteArray(1)
+        Log.d(TAG, "Starting measurement loop")
+        while (true) {
+            // search for header byte 0x54
+            if (input.read(buffer) != 1) continue
+            if (buffer[0] != header[0]) continue
+            if (input.read(buffer) != 1 || buffer[0] != header[1]) continue
+            // read the rest of the packet
+            var read = 0
+            while (read < packet.size - 2) {
+                val r = input.read(packet, 2 + read, packet.size - 2 - read)
+                if (r <= 0) break
+                read += r
+            }
+            if (read != packet.size - 2) {
+                Log.d(TAG, "Incomplete packet read: $read bytes")
+                continue
+            }
+            packet[0] = header[0]
+            packet[1] = header[1]
+            try {
+                val measures = parser.parse(packet)
+                Log.d(TAG, "Parsed packet with ${'$'}{measures.size} measurements")
+                for (m in measures) emit(m)
+            } catch (e: IllegalArgumentException) {
+                Log.d(TAG, "Malformed packet", e)
+            }
+        }
+    }.flowOn(Dispatchers.IO)
+}

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
@@ -31,10 +31,17 @@ class LidarReader(private val port: UsbSerialPort) {
          */
         fun openDefault(context: Context): LidarReader? {
             val manager = context.getSystemService(Context.USB_SERVICE) as UsbManager
+            AppLog.d(TAG, "Searching for USB serial drivers")
             val drivers = UsbSerialProber.getDefaultProber().findAllDrivers(manager)
-            val driver = drivers.firstOrNull() ?: return null
+            AppLog.d(TAG, "Found ${'$'}{drivers.size} drivers")
+            val driver = drivers.firstOrNull()
+            if (driver == null) {
+                AppLog.d(TAG, "No USB serial device available")
+                return null
+            }
             var connection = manager.openDevice(driver.device)
             if (connection == null) {
+                AppLog.d(TAG, "Requesting permission for device")
                 val pi = PendingIntent.getBroadcast(
                     context,
                     0,

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
@@ -18,7 +18,7 @@ import java.io.IOException
  * individual measurements as a [Flow]. The implementation searches for
  * packet headers (0x54, 0x2C) and uses [LidarParser] to decode the packet.
  */
-class LidarReader(private val port: UsbSerialPort) {
+class LidarReader(private val port: UsbSerialPort) : LidarDataSource {
     private val parser = LidarParser()
 
     companion object {
@@ -33,7 +33,7 @@ class LidarReader(private val port: UsbSerialPort) {
             val manager = context.getSystemService(Context.USB_SERVICE) as UsbManager
             AppLog.d(TAG, "Searching for USB serial drivers")
             val drivers = UsbSerialProber.getDefaultProber().findAllDrivers(manager)
-            AppLog.d(TAG, "Found ${'$'}{drivers.size} drivers")
+            AppLog.d(TAG, "Found ${drivers.size} drivers" + drivers)
             val driver = drivers.firstOrNull()
             if (driver == null) {
                 AppLog.d(TAG, "No USB serial device available")
@@ -58,7 +58,7 @@ class LidarReader(private val port: UsbSerialPort) {
         }
     }
 
-    fun measurements(): Flow<LidarMeasurement> = flow {
+    override fun measurements(): Flow<LidarMeasurement> = flow {
         val packet = ByteArray(47)
         val header = byteArrayOf(0x54.toByte(), 0x2C.toByte())
         val buffer = ByteArray(1)

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarReader.kt
@@ -4,7 +4,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.hardware.usb.UsbManager
-import android.util.Log
+import org.example.positioner.logging.AppLog
 import com.hoho.android.usbserial.driver.UsbSerialPort
 import com.hoho.android.usbserial.driver.UsbSerialProber
 import kotlinx.coroutines.Dispatchers
@@ -55,7 +55,7 @@ class LidarReader(private val port: UsbSerialPort) {
         val packet = ByteArray(47)
         val header = byteArrayOf(0x54.toByte(), 0x2C.toByte())
         val buffer = ByteArray(1)
-        Log.d(TAG, "Starting measurement loop")
+        AppLog.d(TAG, "Starting measurement loop")
         while (true) {
             // search for header byte 0x54
             if (port.read(buffer, READ_TIMEOUT) != 1) continue
@@ -71,17 +71,17 @@ class LidarReader(private val port: UsbSerialPort) {
                 read += r
             }
             if (read != packet.size - 2) {
-                Log.d(TAG, "Incomplete packet read: $read bytes")
+                AppLog.d(TAG, "Incomplete packet read: $read bytes")
                 continue
             }
             packet[0] = header[0]
             packet[1] = header[1]
             try {
                 val measures = parser.parse(packet)
-                Log.d(TAG, "Parsed packet with ${'$'}{measures.size} measurements")
+                AppLog.d(TAG, "Parsed packet with ${'$'}{measures.size} measurements")
                 for (m in measures) emit(m)
             } catch (e: IllegalArgumentException) {
-                Log.d(TAG, "Malformed packet", e)
+                AppLog.d(TAG, "Malformed packet", e)
             }
         }
     }.flowOn(Dispatchers.IO)

--- a/app/src/main/kotlin/org/example/positioner/logging/AppLog.kt
+++ b/app/src/main/kotlin/org/example/positioner/logging/AppLog.kt
@@ -1,0 +1,27 @@
+package org.example.positioner.logging
+
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Simple in-memory log store that also forwards messages to Android's Logcat.
+ * Debug level is used by default.
+ */
+object AppLog {
+    private val _logs = MutableStateFlow<List<String>>(emptyList())
+    val logs: StateFlow<List<String>> = _logs
+
+    fun d(tag: String, msg: String, throwable: Throwable? = null) {
+        if (throwable != null) {
+            Log.d(tag, msg, throwable)
+        } else {
+            Log.d(tag, msg)
+        }
+        add("$tag: $msg")
+    }
+
+    private fun add(entry: String) {
+        _logs.value = _logs.value + entry
+    }
+}

--- a/app/src/main/kotlin/org/example/positioner/logging/LogView.kt
+++ b/app/src/main/kotlin/org/example/positioner/logging/LogView.kt
@@ -1,0 +1,21 @@
+package org.example.positioner.logging
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Simple scrolling list that shows log messages stored in [AppLog].
+ */
+@Composable
+fun LogView(logs: List<String>, modifier: Modifier = Modifier) {
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
+        items(logs) { entry ->
+            Text(entry, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}

--- a/docs/cp210x-setup.adoc
+++ b/docs/cp210x-setup.adoc
@@ -7,3 +7,5 @@ To connect the YDLIDAR through a CP210x UART-USB bridge you need to enable a few
 . (Optional) **Developer options** -> *USB debugging* can help when inspecting connection issues.
 
 After granting permission the app will automatically open the CP210x port and start plotting measurements.
+
+NOTE: USB host mode is not supported in the Android emulator. You must use a physical device to communicate with the CP210x bridge.

--- a/docs/cp210x-setup.adoc
+++ b/docs/cp210x-setup.adoc
@@ -1,0 +1,9 @@
+== Using CP210x USB Serial
+
+To connect the YDLIDAR through a CP210x UART-USB bridge you need to enable a few phone features:
+
+. **USB OTG / Host mode** - Make sure your phone supports USB host mode and that the OTG option is enabled in system settings.
+. **USB permission** - When the device is first plugged in, Android will prompt to allow the app access to the USB device. Accept this request so the app can open the serial port.
+. (Optional) **Developer options** -> *USB debugging* can help when inspecting connection issues.
+
+After granting permission the app will automatically open the CP210x port and start plotting measurements.

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -1,0 +1,37 @@
+== Dependency overview
+
+This project uses a small set of libraries. The table below explains why each dependency is included and how it is used.
+
+[cols="1,3",options="header"]
+|===
+|Dependency |Purpose and usage
+
+|AndroidX Activity Compose (activity-compose)
+|Hosts Jetpack Compose UI within an Android Activity.
+
+|Compose BOM
+|Aligns versions of all Compose libraries used in the app.
+
+|Material3
+|Provides Material Design components for Compose UI.
+
+|Android Material Components
+|Legacy Material widget support for interoperability with Compose.
+
+|Compose UI Tooling Preview
+|Enables Compose previews in Android Studio.
+|Compose UI Tooling (debug)
+|Used for on-device inspection and Compose layout debugging.
+
+|Kotlin Coroutines
+|Used by `LidarReader` to stream measurements asynchronously.
+
+|usb-serial-for-android
+|Accesses the CP210x USB serial device to read lidar packets.
+
+|JUnit Jupiter
+|Runs unit tests written with JUnit 5.
+
+|JUnit Platform Launcher
+|Allows Gradle to execute JUnit 5 tests.
+|===

--- a/docs/domain-whitelist.adoc
+++ b/docs/domain-whitelist.adoc
@@ -1,0 +1,8 @@
+The project builds dependencies from several online repositories. Ensure your network allows access to these domains:
+
+- https://services.gradle.org
+- https://plugins.gradle.org
+- https://dl.google.com
+- https://maven.google.com
+- https://repo.maven.apache.org
+- https://jitpack.io

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-gradle = "8.5.0"
+android-gradle = "8.10.1"
 compose-bom = "2024.05.00"
 junit-jupiter = "5.11.3"
 kotlin = "2.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,12 +5,14 @@ junit-jupiter = "5.11.3"
 kotlin = "2.1.0"
 activity-compose = "1.9.0"
 material = "1.12.0"
+coroutines = "1.8.1"
 
 [libraries]
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
+coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlin = "2.1.0"
 activity-compose = "1.9.0"
 material = "1.12.0"
 coroutines = "1.8.1"
+usbserial = "3.5.1"
 
 [libraries]
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
@@ -13,6 +14,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version.ref 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+usbserial = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usbserial" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
## Summary
- add parser and reader for YDLIDAR packets
- plot LIDAR measurements on a Compose canvas
- update `MainActivity` to display the live scan
- include Kotlin coroutines dependency
- log parser and reader activity for debugging

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon` *(fails: no output due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6844ae8ca498832fb2ad0cbaa4df1ab7