### PR TITLE
Fix background LIDAR reader and add scan command

### DIFF
--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -56,15 +56,18 @@ private fun LidarScreen() {
                 FakeLidarReader()
             } else realReader
             AppLog.d("MainActivity", "Starting measurement collection")
-            source.measurements().collect { m ->
-                buffer.add(m)
-                if (buffer.size >= 480) {
-                    value = buffer.toList()
-                    buffer.clear()
+            withContext(Dispatchers.IO) {
+                source.measurements().collect { m ->
+                    buffer.add(m)
+                    if (buffer.size >= 480) {
+                        val result = buffer.toList()
+                        buffer.clear()
+                        withContext(Dispatchers.Main) { value = result }
+                    }
                 }
             }
-        } catch (_: Exception) {
-            // In case opening the serial port fails just keep empty data
+        } catch (e: Exception) {
+            AppLog.d("MainActivity", "Measurement loop failed", e)
         }
     }
     Column(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
## Summary
- start the lidar in continuous mode when opening the serial port
- collect lidar measurements on a background thread
- add log messages and comments

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6845e15772e8832fadab6895d6560f83