### PR TITLE
Add flush interval slider

### DIFF
--- a/docs/flush-interval.adoc
+++ b/docs/flush-interval.adoc
@@ -1,0 +1,5 @@
+== Plot update interval
+
+Use the slider below the plot to control how often new lidar measurements
+are flushed to the UI. The value represents the minimum number of
+milliseconds between updates. By default the app uses 100ms.


### PR DESCRIPTION
## Summary
- throttle LIDAR updates by time instead of count
- expose slider to configure update interval
- document plot update interval control

## Testing
- `./gradlew tasks --no-daemon --console=plain`
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6847bb2e16fc832fa5a2ddb36dcfd509