### PR TITLE
Add raw debug mode

### DIFF
--- a/docs/debug-mode.adoc
+++ b/docs/debug-mode.adoc
@@ -1,0 +1,3 @@
+== Debug hex mode
+
+Set `RAW_DEBUG = true` in `MainActivity.kt` to log raw bytes from the lidar device. The `debugReadHex()` method will print each chunk of data as space separated hexadecimal values.


### PR DESCRIPTION
## Summary
- dump lidar bytes as hex with `debugReadHex()`
- toggle via `RAW_DEBUG` flag in `MainActivity`
- document debug mode

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68558bb311c4832f8bcb9e11576f38df