### PR TITLE
Add lidar session recording and export

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -52,6 +53,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation(libs.coroutines)
     implementation(libs.usbserial)
+    implementation(libs.serialization.json)
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.coroutines)
     implementation(libs.usbserial)
     implementation(libs.serialization.json)
+    implementation(libs.datetime)
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)

--- a/app/src/main/kotlin/org/example/positioner/MainActivity.kt
+++ b/app/src/main/kotlin/org/example/positioner/MainActivity.kt
@@ -6,16 +6,19 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -25,9 +28,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.example.positioner.lidar.LidarMeasurement
 import org.example.positioner.lidar.LidarPlot
 import org.example.positioner.lidar.LidarReader
@@ -55,12 +62,25 @@ fun PositionerApp() {
 @Composable
 private fun LidarScreen() {
     var flushIntervalMs by remember { mutableStateOf(100f) }
+    var recording by remember { mutableStateOf(false) }
+    val sessionData = remember { mutableStateListOf<LidarMeasurement>() }
     val context = LocalContext.current
     val logs by AppLog.logs.collectAsState()
+    val saveLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json")
+    ) { uri ->
+        uri?.let {
+            context.contentResolver.openOutputStream(it)?.use { out ->
+                val json = Json.encodeToString(sessionData)
+                out.write(json.toByteArray())
+            }
+        }
+    }
     val measurements by produceState(
         initialValue = emptyList<LidarMeasurement>(),
         context,
-        flushIntervalMs
+        flushIntervalMs,
+        recording
     ) {
         val buffer = ArrayDeque<LidarMeasurement>()
         var lastFlush = System.currentTimeMillis()
@@ -76,6 +96,7 @@ private fun LidarScreen() {
                 source.measurements().flowOn(Dispatchers.IO).collect { m ->
                     if (buffer.size >= 480) buffer.removeFirst()
                     buffer.addLast(m)
+                    if (recording) sessionData.add(m)
                     val now = System.currentTimeMillis()
                     if (now - lastFlush >= flushIntervalMs.toLong()) {
                         AppLog.d("MainActivity", "Flushing: ${buffer.size}")
@@ -96,6 +117,17 @@ private fun LidarScreen() {
                 .background(Color.White)
                 .border(2.dp, color = Color.Blue)
         )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = { recording = !recording }) {
+                Text(if (recording) "Stop Recording" else "Start Recording")
+            }
+            Button(onClick = { sessionData.clear() }) {
+                Text("Reset")
+            }
+            Button(onClick = { saveLauncher.launch("lidar-session.json") }) {
+                Text("Save")
+            }
+        }
         Slider(
             value = flushIntervalMs,
             onValueChange = { flushIntervalMs = it },

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
@@ -3,10 +3,12 @@ package org.example.positioner.lidar
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.PI
+import kotlinx.serialization.Serializable
 
 /**
  * Single measurement from the LIDAR.
  */
+@Serializable
 data class LidarMeasurement(
     val angle: Float,       // angle in degrees
     val distanceMm: Int,    // distance in millimetres

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
@@ -4,6 +4,25 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.PI
 import kotlinx.serialization.Serializable
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/** Serializer for [OffsetDateTime] using ISO-8601 strings. */
+@Suppress("unused")
+object OffsetDateTimeSerializer : kotlinx.serialization.KSerializer<OffsetDateTime> {
+    override val descriptor = kotlinx.serialization.descriptors.PrimitiveSerialDescriptor(
+        "OffsetDateTime",
+        kotlinx.serialization.descriptors.PrimitiveKind.STRING
+    )
+
+    override fun serialize(encoder: kotlinx.serialization.encoding.Encoder, value: OffsetDateTime) {
+        encoder.encodeString(value.toString())
+    }
+
+    override fun deserialize(decoder: kotlinx.serialization.encoding.Decoder): OffsetDateTime {
+        return OffsetDateTime.parse(decoder.decodeString())
+    }
+}
 
 /**
  * Single measurement from the LIDAR.
@@ -12,7 +31,9 @@ import kotlinx.serialization.Serializable
 data class LidarMeasurement(
     val angle: Float,       // angle in degrees
     val distanceMm: Int,    // distance in millimetres
-    val confidence: Int
+    val confidence: Int,
+    @Serializable(with = OffsetDateTimeSerializer::class)
+    val timestamp: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
 ) {
     /**
      * Convert the polar measurement to cartesian coordinates in metres.

--- a/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
+++ b/app/src/main/kotlin/org/example/positioner/lidar/LidarData.kt
@@ -4,25 +4,9 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.PI
 import kotlinx.serialization.Serializable
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
-/** Serializer for [OffsetDateTime] using ISO-8601 strings. */
-@Suppress("unused")
-object OffsetDateTimeSerializer : kotlinx.serialization.KSerializer<OffsetDateTime> {
-    override val descriptor = kotlinx.serialization.descriptors.PrimitiveSerialDescriptor(
-        "OffsetDateTime",
-        kotlinx.serialization.descriptors.PrimitiveKind.STRING
-    )
-
-    override fun serialize(encoder: kotlinx.serialization.encoding.Encoder, value: OffsetDateTime) {
-        encoder.encodeString(value.toString())
-    }
-
-    override fun deserialize(decoder: kotlinx.serialization.encoding.Decoder): OffsetDateTime {
-        return OffsetDateTime.parse(decoder.decodeString())
-    }
-}
 
 /**
  * Single measurement from the LIDAR.
@@ -32,8 +16,7 @@ data class LidarMeasurement(
     val angle: Float,       // angle in degrees
     val distanceMm: Int,    // distance in millimetres
     val confidence: Int,
-    @Serializable(with = OffsetDateTimeSerializer::class)
-    val timestamp: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+    val timestamp: Instant = Clock.System.now()
 ) {
     /**
      * Convert the polar measurement to cartesian coordinates in metres.

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -32,6 +32,9 @@ This project uses a small set of libraries. The table below explains why each de
 |Kotlin Serialization
 |Encodes recorded lidar sessions as JSON when saving to local storage.
 
+|Kotlinx DateTime
+|Represents timestamps using `Instant` with ISO-8601 serialization.
+
 |JUnit Jupiter
 |Runs unit tests written with JUnit 5.
 

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -29,6 +29,9 @@ This project uses a small set of libraries. The table below explains why each de
 |usb-serial-for-android
 |Accesses the CP210x USB serial device to read lidar packets.
 
+|Kotlin Serialization
+|Encodes recorded lidar sessions as JSON when saving to local storage.
+
 |JUnit Jupiter
 |Runs unit tests written with JUnit 5.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ material = "1.12.0"
 coroutines = "1.8.1"
 usbserial = "3.5.1"
 serialization = "1.6.3"
+datetime = "0.6.2"
 
 [libraries]
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
@@ -17,6 +18,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 usbserial = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usbserial" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ activity-compose = "1.9.0"
 material = "1.12.0"
 coroutines = "1.8.1"
 usbserial = "3.5.1"
+serialization = "1.6.3"
 
 [libraries]
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
@@ -15,8 +16,10 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 material = { module = "com.google.android.material:material", version.ref = "material" }
 coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 usbserial = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usbserial" }
+serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- add Kotlin serialization library
- add dependency docs for serialization
- mark `LidarMeasurement` as `@Serializable`
- add buttons for recording, resetting, and saving lidar sessions
- export recorded session data to JSON using a file picker

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6855d51e5194832f9eb95cf7d7cdc8c1