### PR TITLE
Fix: Add release signing for CI/CD and update workflow

### DIFF
--- a/.github/workflows/build_and_distribute.yml
+++ b/.github/workflows/build_and_distribute.yml
@@ -31,7 +31,17 @@ jobs:
         run: |
           echo "$GOOGLE_SERVICES_JSON" | base64 --decode > app/google-services.json
 
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 --decode > app/release-keystore.jks
+
       - name: Build release APK
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew assembleRelease --no-daemon
 
       - name: Install Firebase CLI
@@ -48,7 +58,7 @@ jobs:
       - name: Distribute to Firebase App Distribution
         run: |
           firebase appdistribution:distribute \
-            app/build/outputs/apk/release/app-release-unsigned.apk \
+            app/build/outputs/apk/release/app-release.apk \
             --app ${{ secrets.FIREBASE_ANDROID_APP_ID }} \
             --release-notes "Automated build from GitHub Actions. See latest changes." \
             --groups "dev"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,15 @@ android {
         versionName = "1.0"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file("release-keystore.jks")
+            storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
+            keyAlias = System.getenv("KEY_ALIAS") ?: ""
+            keyPassword = System.getenv("KEY_PASSWORD") ?: storePassword
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -25,6 +34,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 


### PR DESCRIPTION
- Add release signing config to app/build.gradle.kts using environment variables for keystore and passwords
- Update build_and_distribute.yml to decode keystore and use secrets for signing
- Ensure signed APK is distributed to Firebase App Distribution
- This PR enables secure, automated release builds in CI/CD

Closes #<issue-number-if-applicable>