### PR TITLE
Add settings screen with autoscale controls

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -12,13 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,22 +34,28 @@ import com.koriit.positioner.android.viewmodel.LidarViewModel
 import com.koriit.positioner.android.viewmodel.LidarViewModelFactory
 import kotlinx.datetime.Clock
 
+private enum class Screen { LIDAR, SETTINGS }
+
 @Composable
 fun PositionerApp() {
     MaterialTheme {
         val context = LocalContext.current
         val vm: LidarViewModel = viewModel(factory = LidarViewModelFactory(context))
-        LidarScreen(vm)
+        var screen by remember { mutableStateOf(Screen.LIDAR) }
+        when (screen) {
+            Screen.LIDAR -> LidarScreen(vm) { screen = Screen.SETTINGS }
+            Screen.SETTINGS -> SettingsScreen(vm) { screen = Screen.LIDAR }
+        }
     }
 }
 
 @Composable
-fun LidarScreen(vm: LidarViewModel) {
+fun LidarScreen(vm: LidarViewModel, onOpenSettings: () -> Unit) {
     val measurements by vm.measurements.collectAsState()
     val logs by AppLog.logs.collectAsState()
-    val flushInterval by vm.flushIntervalMs.collectAsState()
     val rotation by vm.rotation.collectAsState()
     val autoScale by vm.autoScale.collectAsState()
+    val showLogs by vm.showLogs.collectAsState()
     val recording by vm.recording.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
     val context = LocalContext.current
@@ -56,6 +63,9 @@ fun LidarScreen(vm: LidarViewModel) {
         uri?.let { vm.saveSession(it, context) }
     }
     Column(modifier = Modifier.fillMaxSize()) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = onOpenSettings) { Text("Settings") }
+        }
         LidarPlot(
             measurements,
             modifier = Modifier
@@ -69,10 +79,6 @@ fun LidarScreen(vm: LidarViewModel) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Button(onClick = { vm.rotate90() }) { Text("Rotate 90°") }
         }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
-            Text("Auto scale")
-        }
         Row(modifier = Modifier.fillMaxWidth()) {
             Button(onClick = { vm.toggleRecording() }) {
                 Text(if (recording) "Stop Recording" else "Start Recording")
@@ -84,21 +90,9 @@ fun LidarScreen(vm: LidarViewModel) {
                 saveLauncher.launch("lidar-session-$timestamp.json")
             }) { Text("Save") }
         }
-        Slider(
-            value = flushInterval,
-            onValueChange = { vm.flushIntervalMs.value = it },
-            valueRange = 50f..1000f,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text("Flush interval: ${'$'}{flushInterval.toInt()} ms")
-        Slider(
-            value = confidence,
-            onValueChange = { vm.confidenceThreshold.value = it },
-            valueRange = 0f..255f,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text("Confidence threshold: ${'$'}{confidence.toInt()}")
-        LogView(logs, modifier = Modifier.height(160.dp))
+        if (showLogs) {
+            LogView(logs, modifier = Modifier.height(160.dp))
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -1,0 +1,59 @@
+package com.koriit.positioner.android.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.koriit.positioner.android.viewmodel.LidarViewModel
+
+@Composable
+fun SettingsScreen(vm: LidarViewModel, onBack: () -> Unit) {
+    val autoScale by vm.autoScale.collectAsState()
+    val showLogs by vm.showLogs.collectAsState()
+    val bufferSize by vm.bufferSize.collectAsState()
+    val flushInterval by vm.flushIntervalMs.collectAsState()
+    val confidence by vm.confidenceThreshold.collectAsState()
+
+    Column {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = onBack) { Text("Back") }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
+            Text("Auto scale")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = showLogs, onCheckedChange = { vm.showLogs.value = it })
+            Text("Show logs")
+        }
+        Slider(
+            value = flushInterval,
+            onValueChange = { vm.flushIntervalMs.value = it },
+            valueRange = 50f..1000f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Flush interval: ${flushInterval.toInt()} ms")
+        Slider(
+            value = confidence,
+            onValueChange = { vm.confidenceThreshold.value = it },
+            valueRange = 0f..255f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Confidence threshold: ${confidence.toInt()}")
+        Slider(
+            value = bufferSize.toFloat(),
+            onValueChange = { vm.bufferSize.value = it.toInt() },
+            valueRange = 100f..1000f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Buffer size: $bufferSize")
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -22,7 +22,9 @@ import kotlinx.serialization.json.Json
 class LidarViewModel(private val context: Context) : ViewModel() {
     val flushIntervalMs = MutableStateFlow(100f)
     val rotation = MutableStateFlow(0)
-    val autoScale = MutableStateFlow(false)
+    val autoScale = MutableStateFlow(true)
+    val showLogs = MutableStateFlow(false)
+    val bufferSize = MutableStateFlow(480)
     val recording = MutableStateFlow(false)
     val confidenceThreshold = MutableStateFlow(200f)
 
@@ -55,7 +57,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
             try {
                 source.measurements().flowOn(Dispatchers.IO).collect { m ->
                     if (m.confidence >= confidenceThreshold.value.toInt()) {
-                        if (buffer.size >= 480) buffer.removeFirst()
+                        if (buffer.size >= bufferSize.value) buffer.removeFirst()
                         buffer.addLast(m)
                         if (recording.value) sessionData.add(m)
                     }

--- a/docs/buffer-size.adoc
+++ b/docs/buffer-size.adoc
@@ -1,0 +1,4 @@
+== Measurement buffer size
+
+The settings screen includes a slider that controls how many lidar data points are kept in memory and displayed on the plot.
+Increasing the value shows more history but uses more memory. The default is 480 points.

--- a/docs/confidence-threshold.adoc
+++ b/docs/confidence-threshold.adoc
@@ -1,0 +1,4 @@
+== Confidence threshold
+
+The settings screen offers a slider that filters out lidar measurements below the selected confidence value.
+Higher values discard more noise but may hide weaker reflections. The default is 200.

--- a/docs/flush-interval.adoc
+++ b/docs/flush-interval.adoc
@@ -1,5 +1,5 @@
 == Plot update interval
 
-Use the slider below the plot to control how often new lidar measurements
-are flushed to the UI. The value represents the minimum number of
-milliseconds between updates. By default the app uses 100ms.
+Use the slider in the settings screen to control how often new lidar
+measurements are flushed to the UI. The value represents the minimum
+number of milliseconds between updates. By default the app uses 100ms.

--- a/docs/plot-options.adoc
+++ b/docs/plot-options.adoc
@@ -1,6 +1,6 @@
 == Plot display options
 
-Two controls below the plot adjust how lidar measurements are rendered.
+The main screen provides a few controls to adjust how lidar measurements are rendered.
 
 * **Rotate 90\u00B0** - rotates the coordinate system clockwise by ninety degrees. Use this when the sensor orientation doesn't match the default plot.
-* **Auto scale** - automatically scales the plot so that all current measurements fit inside the canvas.
+The **Auto scale** option is available from the settings screen. It automatically scales the plot so that all current measurements fit inside the canvas.


### PR DESCRIPTION
## Summary
- add simple settings page with auto scale and log toggle
- move auto scale checkbox and log toggle to the settings page
- enable auto scale by default
- add slider for lidar measurement buffer size
- hide logs unless enabled in settings
- document new buffer size slider
- move flush interval and confidence sliders to settings screen
- fix interpolation of slider labels
- document confidence slider and update flush interval docs

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686a6be583ec832fac2fa364d7f2967e