### PR TITLE
Add orientation aware layout

### DIFF
--- a/docs/orientation.adoc
+++ b/docs/orientation.adoc
@@ -1,0 +1,3 @@
+== Orientation support
+
+The main screen adapts to device orientation. In portrait mode the lidar canvas stretches across the full width with controls below. In landscape the canvas fills the screen height with controls arranged to the right.


### PR DESCRIPTION
## Summary
- make LidarScreen layout responsive to device orientation
- document new orientation behaviour

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686a776d8f2c832f8497b2ecf382c546