### PR TITLE
Fix USB crash and add Crashlytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.google.gms.google-services")
+    alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
@@ -70,6 +71,7 @@ dependencies {
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -10,6 +10,8 @@ import com.koriit.positioner.android.lidar.LidarDataSource
 import com.koriit.positioner.android.lidar.LidarMeasurement
 import com.koriit.positioner.android.lidar.LidarReader
 import com.koriit.positioner.android.logging.AppLog
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.crashlytics.ktx.crashlytics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -69,6 +71,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 }
             } catch (e: Exception) {
                 AppLog.d("LidarViewModel", "Measurement loop failed", e)
+                Firebase.crashlytics.recordException(e)
             }
         }
     }

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -27,7 +27,7 @@ This project uses a small set of libraries. The table below explains why each de
 |Used by `LidarReader` to stream measurements asynchronously.
 
 |usb-serial-for-android
-|Accesses the CP210x USB serial device to read lidar packets.
+|Accesses the CP210x USB serial device to read lidar packets. Updated to 3.9.0 for stability when hot-plugging.
 
 |Kotlin Serialization
 |Encodes recorded lidar sessions as JSON when saving to local storage.
@@ -43,4 +43,6 @@ This project uses a small set of libraries. The table below explains why each de
 
 |JUnit Platform Launcher
 |Allows Gradle to execute JUnit 5 tests.
+|Firebase Crashlytics
+|Collects crash reports for real user sessions.
 |===

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "2.1.0"
 activity-compose = "1.9.0"
 material = "1.12.0"
 coroutines = "1.8.1"
-usbserial = "3.5.1"
+usbserial = "3.9.0"
 serialization = "1.8.1"
 datetime = "0.6.2"
 lifecycle = "2.7.0"
@@ -16,6 +16,7 @@ lifecycle = "2.7.0"
 [libraries]
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
@@ -33,3 +34,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics" , version = "2.9.9" }


### PR DESCRIPTION
## Summary
- bump usb-serial-for-android to 3.9.0
- integrate Firebase Crashlytics
- log exceptions to Crashlytics when lidar loop fails
- document new dependency

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686a7e6ffab4832f85b31e60b2ece573