### PR TITLE
Fix USB permission BroadcastReceiver for Android 12+

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/usb/UsbPermissionHelper.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/usb/UsbPermissionHelper.kt
@@ -25,7 +25,11 @@ object UsbPermissionHelper {
                     }
                 }
             }
-            context.registerReceiver(receiver, IntentFilter(ACTION_USB_PERMISSION))
+            context.registerReceiver(
+                receiver,
+                IntentFilter(ACTION_USB_PERMISSION),
+                Context.RECEIVER_NOT_EXPORTED
+            )
             manager.requestPermission(device, intent)
         }
     }


### PR DESCRIPTION
## Summary
- specify receiver export flag when registering the USB permission BroadcastReceiver

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686ad317a514832fa23234c486b38987