### PR TITLE
Integrate realtime settings panel

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -24,6 +24,7 @@ fun LidarPlot(
     rotation: Int = 0,
     autoScale: Boolean = false,
     confidenceThreshold: Int = 100,
+    gradientMin: Int = 100,
 ) {
     Canvas(modifier = modifier) {
         val points = measurements.map { m ->
@@ -69,7 +70,7 @@ fun LidarPlot(
 
                 // Create gradient color based on confidence (0-255)
                 // 0 = red (low confidence), 255 = green (high confidence)
-                val normalizedConfidence = confidence / 255f
+                val normalizedConfidence = ((confidence - gradientMin) / (255f - gradientMin)).coerceIn(0f, 1f)
                 val color = Color(
                     red = 1f - normalizedConfidence,
                     green = normalizedConfidence,

--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarReader.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarReader.kt
@@ -43,17 +43,12 @@ class LidarReader(private val port: UsbSerialPort) : LidarDataSource {
                 AppLog.d(TAG, "No USB serial device available")
                 return null
             }
-            var connection = manager.openDevice(driver.device)
-            if (connection == null) {
+            if (!manager.hasPermission(driver.device)) {
                 AppLog.d(TAG, "Requesting permission for device")
-                val granted = UsbPermissionHelper.requestPermission(context, manager, driver.device)
-                if (!granted) {
-                    AppLog.d(TAG, "Permission denied for device")
-                    return null
-                }
-                connection = manager.openDevice(driver.device)
-                if (connection == null) return null
+                UsbPermissionHelper.requestPermissionAsync(context, manager, driver.device)
+                return null
             }
+            val connection = manager.openDevice(driver.device) ?: return null
             val port: UsbSerialPort = driver.ports[0]
             AppLog.d(TAG, "Opening serial connection")
             port.open(connection)

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -3,7 +3,6 @@ package com.koriit.positioner.android.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -15,7 +14,7 @@ import androidx.compose.ui.Modifier
 import com.koriit.positioner.android.viewmodel.LidarViewModel
 
 @Composable
-fun SettingsScreen(vm: LidarViewModel, onBack: () -> Unit) {
+fun SettingsPanel(vm: LidarViewModel) {
     val autoScale by vm.autoScale.collectAsState()
     val showLogs by vm.showLogs.collectAsState()
     val bufferSize by vm.bufferSize.collectAsState()
@@ -23,9 +22,6 @@ fun SettingsScreen(vm: LidarViewModel, onBack: () -> Unit) {
     val confidence by vm.confidenceThreshold.collectAsState()
 
     Column {
-        Row(modifier = Modifier.fillMaxWidth()) {
-            Button(onClick = onBack) { Text("Back") }
-        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
             Text("Auto scale")
@@ -39,6 +35,13 @@ fun SettingsScreen(vm: LidarViewModel, onBack: () -> Unit) {
             value = flushInterval,
             onValueChange = { vm.flushIntervalMs.value = it },
             valueRange = 50f..1000f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Color gradient min: ${vm.gradientMin.value.toInt()}")
+        Slider(
+            value = vm.gradientMin.value,
+            onValueChange = { vm.gradientMin.value = it },
+            valueRange = 0f..255f,
             modifier = Modifier.fillMaxWidth(),
         )
         Text("Confidence threshold: ${confidence.toInt()}")

--- a/app/src/main/kotlin/com/koriit/positioner/android/usb/UsbPermissionHelper.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/usb/UsbPermissionHelper.kt
@@ -33,4 +33,9 @@ object UsbPermissionHelper {
             manager.requestPermission(device, intent)
         }
     }
+
+    fun requestPermissionAsync(context: Context, manager: UsbManager, device: UsbDevice) {
+        val intent = PendingIntent.getBroadcast(context, 0, Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_IMMUTABLE)
+        manager.requestPermission(device, intent)
+    }
 }

--- a/docs/buffer-size.adoc
+++ b/docs/buffer-size.adoc
@@ -1,4 +1,4 @@
 == Measurement buffer size
 
-The settings screen includes a slider that controls how many lidar data points are kept in memory and displayed on the plot.
+The settings panel includes a slider that controls how many lidar data points are kept in memory and displayed on the plot.
 Increasing the value shows more history but uses more memory. The default is 480 points.

--- a/docs/confidence-threshold.adoc
+++ b/docs/confidence-threshold.adoc
@@ -1,4 +1,4 @@
 == Confidence threshold
 
-The settings screen offers a slider that filters out lidar measurements below the selected confidence value.
-Higher values discard more noise but may hide weaker reflections. The default is 200.
+The settings panel offers a slider that filters out lidar measurements below the selected confidence value.
+Higher values discard more noise but may hide weaker reflections. The default is 220.

--- a/docs/flush-interval.adoc
+++ b/docs/flush-interval.adoc
@@ -1,5 +1,5 @@
 == Plot update interval
 
-Use the slider in the settings screen to control how often new lidar
+Use the slider in the settings panel to control how often new lidar
 measurements are flushed to the UI. The value represents the minimum
 number of milliseconds between updates. By default the app uses 100ms.

--- a/docs/plot-options.adoc
+++ b/docs/plot-options.adoc
@@ -3,4 +3,5 @@
 The main screen provides a few controls to adjust how lidar measurements are rendered.
 
 * **Rotate 90\u00B0** - rotates the coordinate system clockwise by ninety degrees. Use this when the sensor orientation doesn't match the default plot.
-The **Auto scale** option is available from the settings screen. It automatically scales the plot so that all current measurements fit inside the canvas.
+The **Auto scale** option is available from the settings panel. It automatically scales the plot so that all current measurements fit inside the canvas.
+The panel also includes a **Color gradient min** slider that controls the lowest confidence mapped to green.


### PR DESCRIPTION
## Summary
- show settings as an in-place panel instead of separate screen
- clear buffer on size change and display measurements per second
- make USB permission request asynchronous and retry on plug-in
- add color gradient minimum slider and bump confidence default to 220
- document updated defaults and settings panel

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686ae1579720832fbfdc72b4bd3fd173