### PR TITLE
Add spinner for USB wait and update defaults

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -56,6 +58,7 @@ fun LidarScreen(vm: LidarViewModel) {
     val showLogs by vm.showLogs.collectAsState()
     val recording by vm.recording.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
+    val usbConnected by vm.usbConnected.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val saveLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -77,18 +80,25 @@ fun LidarScreen(vm: LidarViewModel) {
             if (showSettings) {
                 SettingsPanel(vm)
             }
-            LidarPlot(
-                measurements,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
                     .background(Color.White)
-                    .border(2.dp, color = Color.Blue),
-                rotation = rotation,
-                autoScale = autoScale,
-                confidenceThreshold = confidence.toInt(),
-                gradientMin = gradientMin.toInt(),
-            )
+                    .border(2.dp, color = Color.Blue)
+            ) {
+                LidarPlot(
+                    measurements,
+                    modifier = Modifier.fillMaxSize(),
+                    rotation = rotation,
+                    autoScale = autoScale,
+                    confidenceThreshold = confidence.toInt(),
+                    gradientMin = gradientMin.toInt(),
+                )
+                if (!usbConnected) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+            }
             Text("Measurements/s: $mps")
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Button(onClick = { vm.rotate90() }) { Text("Rotate 90°") }
@@ -110,18 +120,25 @@ fun LidarScreen(vm: LidarViewModel) {
         }
     } else {
         Row(modifier = Modifier.fillMaxSize()) {
-            LidarPlot(
-                measurements,
+            Box(
                 modifier = Modifier
                     .fillMaxHeight()
                     .weight(1f)
                     .background(Color.White)
-                    .border(2.dp, color = Color.Blue),
-                rotation = rotation,
-                autoScale = autoScale,
-                confidenceThreshold = confidence.toInt(),
-                gradientMin = gradientMin.toInt(),
-            )
+                    .border(2.dp, color = Color.Blue)
+            ) {
+                LidarPlot(
+                    measurements,
+                    modifier = Modifier.fillMaxSize(),
+                    rotation = rotation,
+                    autoScale = autoScale,
+                    confidenceThreshold = confidence.toInt(),
+                    gradientMin = gradientMin.toInt(),
+                )
+                if (!usbConnected) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+            }
             Column(modifier = Modifier
                 .fillMaxHeight()
                 .weight(1f)) {

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -20,6 +20,7 @@ fun SettingsPanel(vm: LidarViewModel) {
     val bufferSize by vm.bufferSize.collectAsState()
     val flushInterval by vm.flushIntervalMs.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
+    val gradientMin by vm.gradientMin.collectAsState()
 
     Column {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -37,9 +38,9 @@ fun SettingsPanel(vm: LidarViewModel) {
             valueRange = 50f..1000f,
             modifier = Modifier.fillMaxWidth(),
         )
-        Text("Color gradient min: ${vm.gradientMin.value.toInt()}")
+        Text("Color gradient min: ${gradientMin.toInt()}")
         Slider(
-            value = vm.gradientMin.value,
+            value = gradientMin,
             onValueChange = { vm.gradientMin.value = it },
             valueRange = 0f..255f,
             modifier = Modifier.fillMaxWidth(),

--- a/docs/flush-interval.adoc
+++ b/docs/flush-interval.adoc
@@ -2,4 +2,4 @@
 
 Use the slider in the settings panel to control how often new lidar
 measurements are flushed to the UI. The value represents the minimum
-number of milliseconds between updates. By default the app uses 100ms.
+number of milliseconds between updates. By default the app uses 50ms.

--- a/docs/plot-options.adoc
+++ b/docs/plot-options.adoc
@@ -4,4 +4,4 @@ The main screen provides a few controls to adjust how lidar measurements are ren
 
 * **Rotate 90\u00B0** - rotates the coordinate system clockwise by ninety degrees. Use this when the sensor orientation doesn't match the default plot.
 The **Auto scale** option is available from the settings panel. It automatically scales the plot so that all current measurements fit inside the canvas.
-The panel also includes a **Color gradient min** slider that controls the lowest confidence mapped to green.
+The panel also includes a **Color gradient min** slider that controls the lowest confidence mapped to green. The default is 200.


### PR DESCRIPTION
## Summary
- render spinner on the plot when USB is not connected
- fix gradient slider not updating
- lower flush interval default to 50ms
- raise gradient minimum default to 200
- document new defaults

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686d8817c99c832f9246767e02cac6eb