### PR TITLE
Add lidar rotation speed stat and UI improvements

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -141,7 +141,7 @@ private fun DrawScope.drawConfidenceIndicators(
             "Min: $minConf",
             textPadding + 25.dp.toPx(),
             textPadding + 15.dp.toPx(),
-            paint
+            android.graphics.Paint(paint).apply { color = minColor }
         )
 
         // Max confidence indicator (top-right)
@@ -173,7 +173,7 @@ private fun DrawScope.drawConfidenceIndicators(
             "Max: $maxConf",
             size.width - textPadding - indicatorWidth + 25.dp.toPx(),
             textPadding + 15.dp.toPx(),
-            paint
+            android.graphics.Paint(paint).apply { color = maxColor }
         )
 
         // Average confidence indicator (bottom-left)

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -69,6 +69,7 @@ fun LidarScreen(vm: LidarViewModel) {
 
     val gradientMin by vm.gradientMin.collectAsState()
     val mps by vm.measurementsPerSecond.collectAsState()
+    val rps by vm.rotationsPerSecond.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -96,10 +97,17 @@ fun LidarScreen(vm: LidarViewModel) {
                     gradientMin = gradientMin.toInt(),
                 )
                 if (!usbConnected) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator()
+                        Text("waiting for lidar measurements...")
+                    }
                 }
             }
             Text("Measurements/s: $mps")
+            Text("Rotations/s: ${"%.2f".format(rps)}")
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Button(onClick = { vm.rotate90() }) { Text("Rotate 90°") }
             }
@@ -136,7 +144,13 @@ fun LidarScreen(vm: LidarViewModel) {
                     gradientMin = gradientMin.toInt(),
                 )
                 if (!usbConnected) {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator()
+                        Text("waiting for lidar measurements...")
+                    }
                 }
             }
             Column(modifier = Modifier
@@ -163,6 +177,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     }) { Text("Save") }
                 }
                 Text("Measurements/s: $mps")
+                Text("Rotations/s: ${"%.2f".format(rps)}")
                 if (showLogs) {
                     LogView(logs, modifier = Modifier.height(160.dp))
                 }


### PR DESCRIPTION
## Summary
- compute rotations per second from measurement angles
- show RPS value on Lidar screen
- overlay text below spinner while waiting for lidar measurements
- color min/max confidence labels with same gradient as markers

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68741264329c832fb47761189f2d443a