### PR TITLE
Add reusable measurement filter

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/MeasurementFilter.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/MeasurementFilter.kt
@@ -1,0 +1,37 @@
+package com.koriit.positioner.android.lidar
+
+/**
+ * Utility for applying measurement filters.
+ */
+object MeasurementFilter {
+    /**
+     * Apply filtering rules to the provided measurements.
+     *
+     * @param measurements Raw lidar measurements.
+     * @param confidenceThreshold Minimum confidence required.
+     * @param minDistance Minimum distance in metres.
+     * @param isolationDistance Points without neighbours closer than this radius are removed.
+     */
+    fun apply(
+        measurements: List<LidarMeasurement>,
+        confidenceThreshold: Int,
+        minDistance: Float,
+        isolationDistance: Float,
+    ): List<LidarMeasurement> {
+        if (measurements.isEmpty()) return emptyList()
+        val points = measurements.map { it to it.toPoint() }
+        return points.filter { (m, p1) ->
+            if (m.confidence < confidenceThreshold) return@filter false
+            val dist = m.distanceMm / 1000f
+            if (dist < minDistance) return@filter false
+            if (isolationDistance == 0f) return@filter true
+            points.any { (other, p2) ->
+                other !== m &&
+                    kotlin.math.hypot(
+                        (p1.first - p2.first).toDouble(),
+                        (p1.second - p2.second).toDouble(),
+                    ) <= isolationDistance
+            }
+        }.map { it.first }
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -21,6 +21,8 @@ fun SettingsPanel(vm: LidarViewModel) {
     val flushInterval by vm.flushIntervalMs.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
     val gradientMin by vm.gradientMin.collectAsState()
+    val minDistance by vm.minDistance.collectAsState()
+    val isolationDistance by vm.isolationDistance.collectAsState()
 
     Column {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -50,6 +52,20 @@ fun SettingsPanel(vm: LidarViewModel) {
             value = confidence,
             onValueChange = { vm.confidenceThreshold.value = it },
             valueRange = 0f..255f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Min distance: ${"%.2f".format(minDistance)} m")
+        Slider(
+            value = minDistance,
+            onValueChange = { vm.minDistance.value = it },
+            valueRange = 0f..2f,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text("Isolation distance: ${"%.2f".format(isolationDistance)} m")
+        Slider(
+            value = isolationDistance,
+            onValueChange = { vm.isolationDistance.value = it },
+            valueRange = 0f..5f,
             modifier = Modifier.fillMaxWidth(),
         )
         Text("Buffer size: $bufferSize")

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/MeasurementFilterTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/MeasurementFilterTest.kt
@@ -1,0 +1,39 @@
+package com.koriit.positioner.android.lidar
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MeasurementFilterTest {
+    @Test
+    fun filtersByConfidence() {
+        val input = listOf(
+            LidarMeasurement(0f, 1000, 50),
+            LidarMeasurement(90f, 1000, 250),
+        )
+        val result = MeasurementFilter.apply(input, 100, 0f, 0f)
+        assertEquals(1, result.size)
+        assertEquals(250, result[0].confidence)
+    }
+
+    @Test
+    fun filtersByMinDistance() {
+        val input = listOf(
+            LidarMeasurement(0f, 100, 200),
+            LidarMeasurement(90f, 1000, 200),
+        )
+        val result = MeasurementFilter.apply(input, 0, 0.5f, 0f)
+        assertEquals(1, result.size)
+        assertEquals(1000, result[0].distanceMm)
+    }
+
+    @Test
+    fun filtersByIsolation() {
+        val input = listOf(
+            LidarMeasurement(0f, 1000, 200),
+            LidarMeasurement(5f, 1000, 200),
+            LidarMeasurement(90f, 5000, 200),
+        )
+        val result = MeasurementFilter.apply(input, 0, 0f, 1.1f)
+        assertEquals(2, result.size)
+    }
+}

--- a/docs/confidence-threshold.adoc
+++ b/docs/confidence-threshold.adoc
@@ -2,3 +2,4 @@
 
 The settings panel offers a slider that filters out lidar measurements below the selected confidence value.
 Higher values discard more noise but may hide weaker reflections. The default is 220.
+The threshold is applied when rendering so recorded sessions remain unaffected.

--- a/docs/isolation-distance.adoc
+++ b/docs/isolation-distance.adoc
@@ -1,0 +1,5 @@
+== Isolation distance filter
+
+The isolation distance slider removes stray points that have no neighbours within the specified radius.
+The distance is measured in metres. The default value is 1m.
+This filter is applied after measurements are read so recordings keep every data point.

--- a/docs/min-distance.adoc
+++ b/docs/min-distance.adoc
@@ -1,0 +1,5 @@
+== Minimum distance filter
+
+Use this slider in the settings panel to discard points that are too close to the sensor.
+The value represents metres. By default points closer than 0.5m are removed.
+Filtering happens when the plot is drawn so recordings always contain the raw measurements.


### PR DESCRIPTION
## Summary
- centralize all filtering logic in `MeasurementFilter`
- apply filters when flushing measurements instead of discarding data
- keep recordings unfiltered so replay can use different settings
- document that filters affect only rendering
- add unit tests for filtering

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6875f17099a0832f87126baa3cf79f89