### PR TITLE
Add lidar session replay

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
@@ -1,0 +1,47 @@
+package com.koriit.positioner.android.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import com.koriit.positioner.android.viewmodel.LidarViewModel
+
+/**
+ * Playback controls shown when a recording is loaded.
+ *
+ * The composable exposes seek buttons, a progress slider and speed
+ * adjustments so users can inspect captured data.
+ */
+
+@Composable
+fun ReplayControls(vm: LidarViewModel) {
+    val pos by vm.replayPositionMs.collectAsState()
+    val duration by vm.replayDurationMs.collectAsState()
+    val playing by vm.playing.collectAsState()
+    val speed by vm.replaySpeed.collectAsState()
+
+    Column {
+        Slider(
+            value = pos.toFloat(),
+            onValueChange = { vm.seekTo(it.toLong()) },
+            valueRange = 0f..duration.toFloat(),
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Button(onClick = { vm.seekBy(-1000) }) { Text("-1s") }
+            Button(onClick = { vm.togglePlay() }) { Text(if (playing) "Pause" else "Play") }
+            Button(onClick = { vm.seekBy(1000) }) { Text("+1s") }
+            Button(onClick = { vm.changeSpeed(0.5f) }) { Text("Slower") }
+            Text(String.format("%.1fx", speed))
+            Button(onClick = { vm.changeSpeed(2f) }) { Text("Faster") }
+        }
+        Text("${pos/1000}s / ${duration/1000}s")
+    }
+}

--- a/docs/replay-mode.adoc
+++ b/docs/replay-mode.adoc
@@ -1,0 +1,5 @@
+== Replay mode
+
+Use the *Load* button to select a previously saved recording in JSON format. Once loaded, playback controls appear below the plot allowing you to play, pause and seek through the data. Buttons adjust speed or jump forward and backward by one second.
+
+Press *Exit Replay* to return to live mode. Recording or loading another file is disabled while replay is active.


### PR DESCRIPTION
## Summary
- enable replay mode in `LidarViewModel`
- add composable `ReplayControls`
- expose controls in `LidarScreen`
- prevent recording or loading while replay is active or recording
- document replay feature and improve cleanup on exit

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687aa15bb49c832fa97c14fddcdac8f3