### PR TITLE
Improve large replay loading handling

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -60,6 +60,7 @@ fun LidarScreen(vm: LidarViewModel) {
     val recording by vm.recording.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
     val usbConnected by vm.usbConnected.collectAsState()
+    val loading by vm.loadingReplay.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val saveLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -106,7 +107,15 @@ fun LidarScreen(vm: LidarViewModel) {
                     confidenceThreshold = confidence.toInt(),
                     gradientMin = gradientMin.toInt(),
                 )
-                if (!usbConnected && !replaying) {
+                if (loading) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator()
+                        Text("Loading recording...")
+                    }
+                } else if (!usbConnected && !replaying) {
                     Column(
                         modifier = Modifier.align(Alignment.Center),
                         horizontalAlignment = Alignment.CenterHorizontally
@@ -143,7 +152,7 @@ fun LidarScreen(vm: LidarViewModel) {
             Row(modifier = Modifier.fillMaxWidth()) {
                 Button(
                     onClick = { loadLauncher.launch(arrayOf("application/json")) },
-                    enabled = !recording && !replaying
+                    enabled = !recording && !replaying && !loading
                 ) { Text("Load") }
                 if (replaying) {
                     Button(onClick = { vm.exitReplay() }) { Text("Exit Replay") }
@@ -174,7 +183,15 @@ fun LidarScreen(vm: LidarViewModel) {
                     confidenceThreshold = confidence.toInt(),
                     gradientMin = gradientMin.toInt(),
                 )
-                if (!usbConnected && !replaying) {
+                if (loading) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator()
+                        Text("Loading recording...")
+                    }
+                } else if (!usbConnected && !replaying) {
                     Column(
                         modifier = Modifier.align(Alignment.Center),
                         horizontalAlignment = Alignment.CenterHorizontally
@@ -223,7 +240,7 @@ fun LidarScreen(vm: LidarViewModel) {
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Button(
                         onClick = { loadLauncher.launch(arrayOf("application/json")) },
-                        enabled = !recording && !replaying
+                        enabled = !recording && !replaying && !loading
                     ) { Text("Load") }
                     if (replaying) {
                         Button(onClick = { vm.exitReplay() }) { Text("Exit Replay") }


### PR DESCRIPTION
## Summary
- avoid loading entire JSON string in memory when loading a replay
- show loading indicator while a recording is being read
- disable "Load" button during loading
- ensure live reading stops while parsing

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687fd2959198832fa6f0e5da12837c50