### PR TITLE
Fix playback controls and defaults

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.CircularProgressIndicator
@@ -201,9 +203,12 @@ fun LidarScreen(vm: LidarViewModel) {
                     }
                 }
             }
-            Column(modifier = Modifier
-                .fillMaxHeight()
-                .weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+            ) {
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Button(onClick = { showSettings = !showSettings }) { Text("Settings") }
                 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
@@ -2,7 +2,12 @@ package com.koriit.positioner.android.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,9 +42,13 @@ fun ReplayControls(vm: LidarViewModel) {
             Button(onClick = { vm.seekBy(-1000) }) { Text("-1s") }
             Button(onClick = { vm.togglePlay() }) { Text(if (playing) "Pause" else "Play") }
             Button(onClick = { vm.seekBy(1000) }) { Text("+1s") }
-            Button(onClick = { vm.changeSpeed(0.5f) }) { Text("Slower") }
+            IconButton(onClick = { vm.changeSpeed(0.5f) }) {
+                Icon(Icons.Filled.FastRewind, contentDescription = "Slower")
+            }
             Text(String.format("%.1fx", speed))
-            Button(onClick = { vm.changeSpeed(2f) }) { Text("Faster") }
+            IconButton(onClick = { vm.changeSpeed(2f) }) {
+                Icon(Icons.Filled.FastForward, contentDescription = "Faster")
+            }
         }
         Text("${pos/1000}s / ${duration/1000}s")
     }

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -30,8 +30,8 @@ class LidarViewModel(private val context: Context) : ViewModel() {
     companion object {
         const val DEFAULT_FLUSH_INTERVAL_MS = 50f
         const val DEFAULT_BUFFER_SIZE = 480
-        const val DEFAULT_CONFIDENCE_THRESHOLD = 220f
-        const val DEFAULT_GRADIENT_MIN = 200f
+        const val DEFAULT_CONFIDENCE_THRESHOLD = 200f
+        const val DEFAULT_GRADIENT_MIN = 180f
         const val DEFAULT_MIN_DISTANCE = 0.5f
         const val DEFAULT_ISOLATION_DISTANCE = 1f
     }
@@ -121,7 +121,13 @@ class LidarViewModel(private val context: Context) : ViewModel() {
         startLiveReading()
     }
 
-    fun togglePlay() { playing.value = !playing.value }
+    fun togglePlay() {
+        val newState = !playing.value
+        playing.value = newState
+        if (newState && replayMode.value && (readJob == null || !readJob!!.isActive)) {
+            startReplay()
+        }
+    }
 
     fun seekBy(ms: Long) { seekTo(replayPositionMs.value + ms) }
 
@@ -140,6 +146,9 @@ class LidarViewModel(private val context: Context) : ViewModel() {
      */
     fun seekTo(ms: Long) {
         replayPositionMs.value = ms.coerceIn(0L, replayDurationMs.value)
+        if (replayMode.value && playing.value && (readJob == null || !readJob!!.isActive)) {
+            startReplay()
+        }
     }
 
     fun saveSession(uri: Uri, context: Context) {

--- a/docs/confidence-threshold.adoc
+++ b/docs/confidence-threshold.adoc
@@ -1,5 +1,5 @@
 == Confidence threshold
 
 The settings panel offers a slider that filters out lidar measurements below the selected confidence value.
-Higher values discard more noise but may hide weaker reflections. The default is 220.
+Higher values discard more noise but may hide weaker reflections. The default is 200.
 The threshold is applied when rendering so recorded sessions remain unaffected.

--- a/docs/plot-options.adoc
+++ b/docs/plot-options.adoc
@@ -4,4 +4,4 @@ The main screen provides a few controls to adjust how lidar measurements are ren
 
 * **Rotate 90\u00B0** - rotates the coordinate system clockwise by ninety degrees. Use this when the sensor orientation doesn't match the default plot.
 The **Auto scale** option is available from the settings panel. It automatically scales the plot so that all current measurements fit inside the canvas.
-The panel also includes a **Color gradient min** slider that controls the lowest confidence mapped to green. The default is 200.
+The panel also includes a **Color gradient min** slider that controls the lowest confidence mapped to green. The default is 180.


### PR DESCRIPTION
## Summary
- update confidence/gradient defaults
- allow playback restart after seeking or finishing
- use icons for speed controls
- ensure settings panel scrolls in landscape
- document new defaults

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6885dff83ea0832f85e6a18adbe06f1c