### PR TITLE
Add floor plan overlay and neighbour filter

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/GeoJsonParser.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/GeoJsonParser.kt
@@ -1,0 +1,78 @@
+package com.koriit.positioner.android.lidar
+
+import android.content.Context
+import android.net.Uri
+import org.json.JSONArray
+import org.json.JSONObject
+
+object GeoJsonParser {
+    fun readFloorPlans(context: Context, uris: List<Uri>): List<List<Pair<Float, Float>>> {
+        val result = mutableListOf<List<Pair<Float, Float>>>()
+        for (uri in uris) {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val text = input.bufferedReader().use { it.readText() }
+                result += parse(text)
+            }
+        }
+        return result
+    }
+
+    fun parse(json: String): List<List<Pair<Float, Float>>> {
+        val obj = JSONObject(json)
+        return when (obj.getString("type")) {
+            "FeatureCollection" -> parseFeatureCollection(obj)
+            "Feature" -> parseFeature(obj)
+            "LineString", "Polygon", "MultiPolygon" -> parseGeometry(obj)
+            else -> emptyList()
+        }
+    }
+
+    private fun parseFeatureCollection(obj: JSONObject): List<List<Pair<Float, Float>>> {
+        val arr = obj.getJSONArray("features")
+        val list = mutableListOf<List<Pair<Float, Float>>>()
+        for (i in 0 until arr.length()) {
+            list += parseFeature(arr.getJSONObject(i))
+        }
+        return list
+    }
+
+    private fun parseFeature(obj: JSONObject): List<List<Pair<Float, Float>>> {
+        val geom = obj.getJSONObject("geometry")
+        return parseGeometry(geom)
+    }
+
+    private fun parseGeometry(obj: JSONObject): List<List<Pair<Float, Float>>> {
+        return when (obj.getString("type")) {
+            "LineString" -> listOf(parseCoordinateList(obj.getJSONArray("coordinates")))
+            "Polygon" -> {
+                val coords = obj.getJSONArray("coordinates")
+                (0 until coords.length()).map { idx ->
+                    parseCoordinateList(coords.getJSONArray(idx))
+                }
+            }
+            "MultiPolygon" -> {
+                val coords = obj.getJSONArray("coordinates")
+                val list = mutableListOf<List<Pair<Float, Float>>>()
+                for (i in 0 until coords.length()) {
+                    val poly = coords.getJSONArray(i)
+                    for (j in 0 until poly.length()) {
+                        list += parseCoordinateList(poly.getJSONArray(j))
+                    }
+                }
+                list
+            }
+            else -> emptyList()
+        }
+    }
+
+    private fun parseCoordinateList(arr: JSONArray): List<Pair<Float, Float>> {
+        val list = mutableListOf<Pair<Float, Float>>()
+        for (i in 0 until arr.length()) {
+            val coord = arr.getJSONArray(i)
+            val x = coord.getDouble(0).toFloat()
+            val y = coord.getDouble(1).toFloat()
+            list += x to y
+        }
+        return list
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -25,6 +25,7 @@ fun LidarPlot(
     autoScale: Boolean = false,
     confidenceThreshold: Int = 100,
     gradientMin: Int = 100,
+    floorPlan: List<List<Pair<Float, Float>>> = emptyList(),
 ) {
     Canvas(modifier = modifier) {
         val points = measurements.map { m ->
@@ -64,6 +65,32 @@ fun LidarPlot(
         }
 
         translate(left = center.x, top = center.y) {
+            floorPlan.forEach { polygon ->
+                for (i in 0 until polygon.size - 1) {
+                    var (x1, y1) = polygon[i]
+                    var (x2, y2) = polygon[i + 1]
+                    if (rotation != 0) {
+                        val angleRad = Math.toRadians(rotation.toDouble())
+                        val cos = kotlin.math.cos(angleRad).toFloat()
+                        val sin = kotlin.math.sin(angleRad).toFloat()
+                        val rx1 = x1 * cos - y1 * sin
+                        val ry1 = x1 * sin + y1 * cos
+                        val rx2 = x2 * cos - y2 * sin
+                        val ry2 = x2 * sin + y2 * cos
+                        x1 = rx1
+                        y1 = ry1
+                        x2 = rx2
+                        y2 = ry2
+                    }
+                    drawLine(
+                        color = Color.Blue,
+                        start = Offset(x1 * scale, -y1 * scale),
+                        end = Offset(x2 * scale, -y2 * scale),
+                        strokeWidth = 2f
+                    )
+                }
+            }
+
             points.forEach { (x, y, confidence) ->
                 val px = x * scale
                 val py = -y * scale
@@ -223,5 +250,6 @@ fun PreviewLidarPlot() {
         rotation = 0,
         autoScale = true,
         confidenceThreshold = 100,
+        floorPlan = emptyList(),
     )
 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/MeasurementFilter.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/MeasurementFilter.kt
@@ -10,13 +10,15 @@ object MeasurementFilter {
      * @param measurements Raw lidar measurements.
      * @param confidenceThreshold Minimum confidence required.
      * @param minDistance Minimum distance in metres.
-     * @param isolationDistance Points without neighbours closer than this radius are removed.
+     * @param isolationDistance Points without enough neighbours closer than this radius are removed.
+     * @param minNeighbours Minimum number of neighbours required within the isolation distance.
      */
     fun apply(
         measurements: List<LidarMeasurement>,
         confidenceThreshold: Int,
         minDistance: Float,
         isolationDistance: Float,
+        minNeighbours: Int,
     ): List<LidarMeasurement> {
         if (measurements.isEmpty()) return emptyList()
         val points = measurements.map { it to it.toPoint() }
@@ -24,14 +26,19 @@ object MeasurementFilter {
             if (m.confidence < confidenceThreshold) return@filter false
             val dist = m.distanceMm / 1000f
             if (dist < minDistance) return@filter false
-            if (isolationDistance == 0f) return@filter true
-            points.any { (other, p2) ->
-                other !== m &&
-                    kotlin.math.hypot(
-                        (p1.first - p2.first).toDouble(),
-                        (p1.second - p2.second).toDouble(),
-                    ) <= isolationDistance
+            if (isolationDistance == 0f || minNeighbours <= 0) return@filter true
+            var neighbours = 0
+            for ((other, p2) in points) {
+                if (other === m) continue
+                val dx = p1.first - p2.first
+                val dy = p1.second - p2.second
+                val distSq = dx * dx + dy * dy
+                if (distSq <= isolationDistance * isolationDistance) {
+                    neighbours++
+                    if (neighbours >= minNeighbours) break
+                }
             }
+            neighbours >= minNeighbours
         }.map { it.first }
     }
 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -26,6 +26,7 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val gradientMin by vm.gradientMin.collectAsState()
     val minDistance by vm.minDistance.collectAsState()
     val isolationDistance by vm.isolationDistance.collectAsState()
+    val isolationMinNeighbours by vm.isolationMinNeighbours.collectAsState()
 
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -70,6 +71,13 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
             onValueChange = { vm.isolationDistance.value = it },
             valueRange = 0f..5f,
             onReset = { vm.resetIsolationDistance() }
+        )
+        Text("Isolation neighbours: $isolationMinNeighbours")
+        SliderWithActions(
+            value = isolationMinNeighbours.toFloat(),
+            onValueChange = { vm.isolationMinNeighbours.value = it.toInt() },
+            valueRange = 0f..10f,
+            onReset = { vm.resetIsolationMinNeighbours() }
         )
         Text("Buffer size: $bufferSize")
         SliderWithActions(

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/MeasurementFilterTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/MeasurementFilterTest.kt
@@ -10,7 +10,7 @@ class MeasurementFilterTest {
             LidarMeasurement(0f, 1000, 50),
             LidarMeasurement(90f, 1000, 250),
         )
-        val result = MeasurementFilter.apply(input, 100, 0f, 0f)
+        val result = MeasurementFilter.apply(input, 100, 0f, 0f, 0)
         assertEquals(1, result.size)
         assertEquals(250, result[0].confidence)
     }
@@ -21,7 +21,7 @@ class MeasurementFilterTest {
             LidarMeasurement(0f, 100, 200),
             LidarMeasurement(90f, 1000, 200),
         )
-        val result = MeasurementFilter.apply(input, 0, 0.5f, 0f)
+        val result = MeasurementFilter.apply(input, 0, 0.5f, 0f, 0)
         assertEquals(1, result.size)
         assertEquals(1000, result[0].distanceMm)
     }
@@ -33,7 +33,18 @@ class MeasurementFilterTest {
             LidarMeasurement(5f, 1000, 200),
             LidarMeasurement(90f, 5000, 200),
         )
-        val result = MeasurementFilter.apply(input, 0, 0f, 1.1f)
+        val result = MeasurementFilter.apply(input, 0, 0f, 1.1f, 1)
         assertEquals(2, result.size)
+    }
+
+    @Test
+    fun filtersByMinNeighbours() {
+        val input = listOf(
+            LidarMeasurement(0f, 1000, 200),
+            LidarMeasurement(5f, 1000, 200),
+            LidarMeasurement(6f, 1000, 200),
+        )
+        val result = MeasurementFilter.apply(input, 0, 0f, 1.1f, 2)
+        assertEquals(3, result.size)
     }
 }

--- a/docs/floor-plan.adoc
+++ b/docs/floor-plan.adoc
@@ -1,0 +1,5 @@
+== Floor plan overlay
+
+You can load one or more GeoJSON files describing your building layout.
+Each LineString or Polygon ring is drawn in blue on top of the LiDAR plot.
+This helps orient measurements relative to real walls.

--- a/docs/isolation-distance.adoc
+++ b/docs/isolation-distance.adoc
@@ -1,5 +1,6 @@
 == Isolation distance filter
 
 The isolation distance slider removes stray points that have no neighbours within the specified radius.
-The distance is measured in metres. The default value is 1m.
+The distance is measured in metres. The default value is 0.75m.
+Points must have at least two neighbours within this radius to remain visible.
 This filter is applied after measurements are read so recordings keep every data point.


### PR DESCRIPTION
## Summary
- refine `MeasurementFilter` to require a minimum neighbour count
- update defaults for isolation to 0.75m and two neighbours
- expose new options in `LidarViewModel` and settings UI
- allow loading one or many GeoJSON files as a floor plan
- render uploaded walls in blue
- document floor plan feature and updated isolation defaults
- update unit tests

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68860e39e05c832fb52c23cf153f2537