### PR TITLE
Handle NBSP in GeoJSON parser

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
 
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.org.json)
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/GeoJsonParser.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/GeoJsonParser.kt
@@ -18,7 +18,11 @@ object GeoJsonParser {
     }
 
     fun parse(json: String): List<List<Pair<Float, Float>>> {
-        val obj = JSONObject(json)
+        // Some GeoJSON files may contain non-breaking spaces (U+00A0),
+        // which `JSONObject` fails to treat as valid whitespace.
+        // Normalize the input before parsing to avoid `JSONException`.
+        val normalized = json.replace('\u00A0', ' ')
+        val obj = JSONObject(normalized)
         return when (obj.getString("type")) {
             "FeatureCollection" -> parseFeatureCollection(obj)
             "Feature" -> parseFeature(obj)

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/GeoJsonParserTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/GeoJsonParserTest.kt
@@ -1,0 +1,17 @@
+package com.koriit.positioner.android.lidar
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GeoJsonParserTest {
+    @Test
+    fun parsesJsonWithNbsp() {
+        val json = "{\n\u00A0 \"type\": \"Feature\",\n\u00A0 \"geometry\": {\n\u00A0\u00A0 \"type\": \"Polygon\",\n\u00A0\u00A0 \"coordinates\": [[[10.0, 20.0], [13.42, 20.0], [13.42, 22.1], [10.0, 22.1], [10.0, 20.0]]]\n\u00A0 }\n}"
+        val result = GeoJsonParser.parse(json)
+        assertEquals(1, result.size)
+        assertEquals(5, result[0].size)
+        assertEquals(10.0f to 20.0f, result[0][0])
+        assertEquals(13.42f to 22.1f, result[0][2])
+    }
+}
+

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -45,6 +45,8 @@ This project uses a small set of libraries. The table below explains why each de
 
 |JUnit Platform Launcher
 |Allows Gradle to execute JUnit 5 tests.
+|org.json
+|Provides a full implementation of `JSONObject` for unit tests.
 |Firebase Crashlytics
 |Collects crash reports for real user sessions.
 |===

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ usbserial = "3.9.0"
 serialization = "1.8.1"
 datetime = "0.6.2"
 lifecycle = "2.7.0"
+json = "20250517"
 
 [libraries]
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
@@ -28,6 +29,7 @@ datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "d
 lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 compose-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+org-json = { module = "org.json:json", version.ref = "json" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }


### PR DESCRIPTION
## Summary
- normalize GeoJSON input to strip non-breaking spaces before parsing
- cover edge case with unit test
- add `org.json` dependency for tests

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688631f465d8832fa289efd7b8d7901d