### PR TITLE
Fix floor plan scaling

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -42,13 +42,18 @@ fun LidarPlot(
             Triple(x, y, m.confidence)
         }
 
+        val planRange = floorPlan.flatten().maxOfOrNull { (x, y) ->
+            kotlin.math.hypot(x.toDouble(), y.toDouble()).toFloat()
+        } ?: 0f
+
+        val pointRange = points.maxOfOrNull { (x, y, _) ->
+            kotlin.math.hypot(x.toDouble(), y.toDouble()).toFloat()
+        } ?: 0f
+
         val maxRange = if (autoScale) {
-            points.maxOfOrNull { (x, y, _) ->
-                kotlin.math.hypot(x.toDouble(), y.toDouble()).toFloat()
-            }
-                ?: 1f
+            maxOf(planRange, pointRange).coerceAtLeast(1f)
         } else {
-            4f // metres, matches python default
+            maxOf(4f, planRange)
         }
 
         val scale = min(size.width, size.height) / (maxRange * 2f)

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -103,7 +103,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     .fillMaxWidth()
                     .weight(1f)
                     .background(Color.White)
-                    .border(2.dp, color = Color.Blue)
+                    .border(2.dp, color = Color.Black)
             ) {
                 LidarPlot(
                     measurements,
@@ -186,7 +186,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     .fillMaxHeight()
                     .weight(1f)
                     .background(Color.White)
-                    .border(2.dp, color = Color.Blue)
+                    .border(2.dp, color = Color.Black)
             ) {
                 LidarPlot(
                     measurements,

--- a/docs/floor-plan.adoc
+++ b/docs/floor-plan.adoc
@@ -1,5 +1,7 @@
 == Floor plan overlay
 
 You can load one or more GeoJSON files describing your building layout.
-Each LineString or Polygon ring is drawn in blue on top of the LiDAR plot.
+Each `LineString` or `Polygon` ring is drawn in blue on top of the LiDAR plot.
+When *Auto scale* is enabled the canvas size now also accounts for the loaded
+floor plan so the outline remains visible even before any LiDAR points appear.
 This helps orient measurements relative to real walls.


### PR DESCRIPTION
## Summary
- include floor plan outline when determining plot scale
- document auto scaling improvement

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68866a8f7798832fbb7b5d9bbd2904d7