### PR TITLE
Add JTS-based position estimation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.datetime)
     implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.jts.core)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)

--- a/app/src/main/kotlin/com/koriit/positioner/android/localization/PositionEstimator.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/localization/PositionEstimator.kt
@@ -1,0 +1,119 @@
+package com.koriit.positioner.android.localization
+
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Polygon
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Estimate orientation, scale and position of the sensor relative to a polygon floor plan.
+ * Uses JTS for geometric calculations to avoid manual intersection code.
+ */
+object PositionEstimator {
+    data class Estimate(
+        val orientation: Float,
+        val scale: Float,
+        val position: Pair<Float, Float>,
+    )
+
+    private val geomFactory = GeometryFactory()
+
+    private fun buildPolygon(points: List<Pair<Float, Float>>): Polygon {
+        val coords = points.map { (x, y) -> Coordinate(x.toDouble(), y.toDouble()) } +
+            listOf(Coordinate(points.first().first.toDouble(), points.first().second.toDouble()))
+        return geomFactory.createPolygon(coords.toTypedArray())
+    }
+
+    private fun rayDistance(polygon: Polygon, origin: Coordinate, angleDeg: Int): Double {
+        val rad = Math.toRadians(angleDeg.toDouble())
+        val dx = sin(rad)
+        val dy = cos(rad)
+        val far = Coordinate(origin.x + dx * 1000, origin.y + dy * 1000)
+        val line = geomFactory.createLineString(arrayOf(origin, far))
+        val intersection = polygon.boundary.intersection(line)
+        if (intersection.isEmpty) return Double.POSITIVE_INFINITY
+        return intersection.coordinates.minOf { origin.distance(it) }
+    }
+
+    private fun distanceProfile(polygon: Polygon, origin: Coordinate): DoubleArray {
+        val profile = DoubleArray(360)
+        for (deg in 0 until 360) {
+            profile[deg] = rayDistance(polygon, origin, deg)
+        }
+        return profile
+    }
+
+    /**
+     * Estimate orientation, scale and position relative to [polygonPoints].
+     */
+    fun estimate(
+        measurements: List<LidarMeasurement>,
+        polygonPoints: List<Pair<Float, Float>>,
+    ): Estimate? {
+        if (measurements.isEmpty() || polygonPoints.size < 3) return null
+        val polygon = buildPolygon(polygonPoints)
+        val center = polygon.centroid.coordinate
+        val profile = distanceProfile(polygon, center)
+
+        val measByDeg = DoubleArray(360) { Double.NaN }
+        val counts = IntArray(360)
+        for (m in measurements) {
+            val idx = ((m.angle + 360) % 360).toInt()
+            val dist = m.distanceMm / 1000.0
+            measByDeg[idx] = if (measByDeg[idx].isNaN()) dist else measByDeg[idx] + dist
+            counts[idx]++
+        }
+        for (i in 0 until 360) if (counts[i] > 0) measByDeg[i] /= counts[i]
+
+        var bestOrientation = 0
+        var bestScale = 1.0
+        var bestError = Double.POSITIVE_INFINITY
+
+        for (orient in 0 until 360) {
+            var sumD2 = 0.0
+            var sumMD = 0.0
+            var count = 0
+            for (i in 0 until 360) {
+                val m = measByDeg[i]
+                if (m.isNaN()) continue
+                val d = profile[(i + orient) % 360]
+                sumMD += m * d
+                sumD2 += d * d
+                count++
+            }
+            if (count < 10 || sumD2 == 0.0) continue
+            val scale = sumMD / sumD2
+            var error = 0.0
+            for (i in 0 until 360) {
+                val m = measByDeg[i]
+                if (m.isNaN()) continue
+                val d = profile[(i + orient) % 360] * scale
+                val diff = m - d
+                error += diff * diff
+            }
+            error /= count
+            if (error < bestError) {
+                bestError = error
+                bestOrientation = orient
+                bestScale = scale
+            }
+        }
+
+        // Compute sensor position as difference between measured centroid and polygon centroid
+        val transformed = measurements.map { m ->
+            val r = m.distanceMm / 1000.0 * bestScale
+            val ang = Math.toRadians(m.angle + bestOrientation.toDouble())
+            val x = sin(ang) * r
+            val y = cos(ang) * r
+            Coordinate(x, y)
+        }
+        val multi = geomFactory.createMultiPointFromCoords(transformed.toTypedArray())
+        val measCentroid = multi.centroid.coordinate
+        val tx = (measCentroid.x - center.x).toFloat()
+        val ty = (measCentroid.y - center.y).toFloat()
+
+        return Estimate(bestOrientation.toFloat(), bestScale.toFloat(), tx to ty)
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -64,6 +64,9 @@ fun LidarScreen(vm: LidarViewModel) {
     val usbConnected by vm.usbConnected.collectAsState()
     val loading by vm.loadingReplay.collectAsState()
     val floorPlan by vm.floorPlan.collectAsState()
+    val planOrientation by vm.planOrientation.collectAsState()
+    val planScale by vm.planScale.collectAsState()
+    val userPosition by vm.userPosition.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val saveLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -113,6 +116,9 @@ fun LidarScreen(vm: LidarViewModel) {
                     confidenceThreshold = confidence.toInt(),
                     gradientMin = gradientMin.toInt(),
                     floorPlan = floorPlan,
+                    planOrientation = planOrientation,
+                    planScale = planScale,
+                    userPosition = userPosition,
                 )
                 if (loading) {
                     Column(
@@ -196,6 +202,9 @@ fun LidarScreen(vm: LidarViewModel) {
                     confidenceThreshold = confidence.toInt(),
                     gradientMin = gradientMin.toInt(),
                     floorPlan = floorPlan,
+                    planOrientation = planOrientation,
+                    planScale = planScale,
+                    userPosition = userPosition,
                 )
                 if (loading) {
                     Column(

--- a/app/src/test/kotlin/com/koriit/positioner/android/localization/PositionEstimatorTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/localization/PositionEstimatorTest.kt
@@ -1,0 +1,32 @@
+package com.koriit.positioner.android.localization
+
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PositionEstimatorTest {
+    @Test
+    fun estimatesOrientationAndScale() {
+        val square = listOf(
+            -1f to -1f,
+            1f to -1f,
+            1f to 1f,
+            -1f to 1f,
+            -1f to -1f,
+        )
+        val measurements = mutableListOf<LidarMeasurement>()
+        val orientation = 45f
+        val scale = 1.0f
+        val profile = PositionEstimatorTestHelper.profile(square)
+        for (deg in 0 until 360 step 10) {
+            val worldAngle = (deg + orientation).toInt() % 360
+            val dist = profile[worldAngle] * scale
+            measurements.add(LidarMeasurement(deg.toFloat(), (dist * 1000).toInt(), 200))
+        }
+        val est = PositionEstimator.estimate(measurements, square)!!
+        assertEquals(orientation, est.orientation, 1f)
+        assertEquals(scale, est.scale, 0.01f)
+        assertEquals(0f, est.position.first, 0.1f)
+        assertEquals(0f, est.position.second, 0.1f)
+    }
+}

--- a/app/src/test/kotlin/com/koriit/positioner/android/localization/PositionEstimatorTestHelper.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/localization/PositionEstimatorTestHelper.kt
@@ -1,0 +1,31 @@
+package com.koriit.positioner.android.localization
+
+import org.locationtech.jts.geom.Coordinate
+import org.locationtech.jts.geom.GeometryFactory
+import org.locationtech.jts.geom.Polygon
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal object PositionEstimatorTestHelper {
+    private val geomFactory = GeometryFactory()
+
+    private fun polygon(points: List<Pair<Float, Float>>): Polygon {
+        val coords = points.map { (x, y) -> Coordinate(x.toDouble(), y.toDouble()) } +
+            listOf(Coordinate(points.first().first.toDouble(), points.first().second.toDouble()))
+        return geomFactory.createPolygon(coords.toTypedArray())
+    }
+
+    fun profile(points: List<Pair<Float, Float>>): DoubleArray {
+        val poly = polygon(points)
+        val center = poly.centroid.coordinate
+        val profile = DoubleArray(360)
+        for (deg in 0 until 360) {
+            val rad = Math.toRadians(deg.toDouble())
+            val far = Coordinate(center.x + sin(rad) * 1000, center.y + cos(rad) * 1000)
+            val line = geomFactory.createLineString(arrayOf(center, far))
+            val inter = poly.boundary.intersection(line)
+            profile[deg] = if (inter.isEmpty) 0.0 else inter.coordinates.minOf { center.distance(it) }
+        }
+        return profile
+    }
+}

--- a/docs/dependencies.adoc
+++ b/docs/dependencies.adoc
@@ -47,6 +47,8 @@ This project uses a small set of libraries. The table below explains why each de
 |Allows Gradle to execute JUnit 5 tests.
 |org.json
 |Provides a full implementation of `JSONObject` for unit tests.
+|JTS Topology Suite
+|Provides robust geometric calculations like polygon intersections and centroids for the position estimation logic.
 |Firebase Crashlytics
 |Collects crash reports for real user sessions.
 |===

--- a/docs/floor-plan.adoc
+++ b/docs/floor-plan.adoc
@@ -5,3 +5,7 @@ Each `LineString` or `Polygon` ring is drawn in blue on top of the LiDAR plot.
 When *Auto scale* is enabled the canvas size now also accounts for the loaded
 floor plan so the outline remains visible even before any LiDAR points appear.
 This helps orient measurements relative to real walls.
+
+The first loaded polygon is also used to estimate the sensor orientation, scale
+and the user's position. As new measurements arrive the red dot moves around the
+map to reflect the estimated location of the device.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ serialization = "1.8.1"
 datetime = "0.6.2"
 lifecycle = "2.7.0"
 json = "20250517"
+jts = "1.19.0"
 
 [libraries]
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
@@ -30,6 +31,7 @@ lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 compose-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 org-json = { module = "org.json:json", version.ref = "json" }
+jts-core = { module = "org.locationtech.jts:jts-core", version.ref = "jts" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }


### PR DESCRIPTION
## Summary
- introduce JTS Topology Suite dependency
- rewrite `PositionEstimator` using JTS to compute polygon intersections
- update `LidarViewModel` to continuously update orientation, scale and user position
- show updated docs about moving red dot on the map
- add tests for `PositionEstimator`

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68889b158e64832fad8f22034684cb12