### PR TITLE
Add pose estimation performance metrics

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
@@ -3,6 +3,7 @@ package com.koriit.positioner.android.localization
 import com.koriit.positioner.android.lidar.LidarMeasurement
 import kotlin.math.cos
 import kotlin.math.sin
+import kotlin.system.measureTimeMillis
 
 /**
  * Estimate sensor pose relative to a floor plan using an occupancy grid.
@@ -16,14 +17,23 @@ object OccupancyPoseEstimator {
         val position: Pair<Float, Float>,
     )
 
+    /**
+     * Result of a pose estimation attempt including performance statistics.
+     */
+    data class Result(
+        val estimate: Estimate?,
+        val combinations: Long,
+        val durationMs: Long,
+    )
+
     fun estimate(
         measurements: List<LidarMeasurement>,
         grid: OccupancyGrid,
         orientationStep: Int = 5,
         scaleRange: ClosedFloatingPointRange<Float> = 0.8f..1.2f,
         scaleStep: Float = 0.05f,
-    ): Estimate? {
-        if (measurements.isEmpty()) return null
+    ): Result {
+        if (measurements.isEmpty()) return Result(null, 0, 0)
         var bestScore = -1
         var bestOrientation = 0
         var bestScale = 1f
@@ -33,47 +43,54 @@ object OccupancyPoseEstimator {
         val gridMaxX = grid.originX + grid.width * grid.cellSize
         val gridMaxY = grid.originY + grid.height * grid.cellSize
 
-        var orient = 0
-        while (orient < 360) {
-            val angleRad = Math.toRadians(orient.toDouble())
-            val cosA = cos(angleRad).toFloat()
-            val sinA = sin(angleRad).toFloat()
-            var scale = scaleRange.start
-            while (scale <= scaleRange.endInclusive + 1e-6f) {
-                val transformed = measurements.map { m ->
-                    val r = m.distanceMm / 1000f * scale
-                    val mRad = Math.toRadians(m.angle.toDouble())
-                    val x = sin(mRad).toFloat() * r
-                    val y = cos(mRad).toFloat() * r
-                    val rx = x * cosA - y * sinA
-                    val ry = x * sinA + y * cosA
-                    rx to ry
-                }
-
-                var y = grid.originY
-                while (y <= gridMaxY) {
-                    var x = grid.originX
-                    while (x <= gridMaxX) {
-                        var score = 0
-                        for ((px, py) in transformed) {
-                            if (grid.isOccupied(px + x, py + y)) score++
-                        }
-                        if (score > bestScore) {
-                            bestScore = score
-                            bestOrientation = orient
-                            bestScale = scale
-                            bestX = x
-                            bestY = y
-                        }
-                        x += grid.cellSize
+        var combinations = 0L
+        val duration = measureTimeMillis {
+            var orient = 0
+            while (orient < 360) {
+                val angleRad = Math.toRadians(orient.toDouble())
+                val cosA = cos(angleRad).toFloat()
+                val sinA = sin(angleRad).toFloat()
+                var scale = scaleRange.start
+                while (scale <= scaleRange.endInclusive + 1e-6f) {
+                    val transformed = measurements.map { m ->
+                        val r = m.distanceMm / 1000f * scale
+                        val mRad = Math.toRadians(m.angle.toDouble())
+                        val x = sin(mRad).toFloat() * r
+                        val y = cos(mRad).toFloat() * r
+                        val rx = x * cosA - y * sinA
+                        val ry = x * sinA + y * cosA
+                        rx to ry
                     }
-                    y += grid.cellSize
+
+                    var y = grid.originY
+                    while (y <= gridMaxY) {
+                        var x = grid.originX
+                        while (x <= gridMaxX) {
+                            combinations++
+                            var score = 0
+                            for ((px, py) in transformed) {
+                                if (grid.isOccupied(px + x, py + y)) score++
+                            }
+                            if (score > bestScore) {
+                                bestScore = score
+                                bestOrientation = orient
+                                bestScale = scale
+                                bestX = x
+                                bestY = y
+                            }
+                            x += grid.cellSize
+                        }
+                        y += grid.cellSize
+                    }
+                    scale += scaleStep
                 }
-                scale += scaleStep
+                orient += orientationStep
             }
-            orient += orientationStep
         }
-        if (bestScore <= 0) return null
-        return Estimate(bestOrientation.toFloat(), bestScale, bestX to bestY)
+        if (bestScore <= 0) {
+            return Result(null, combinations, duration)
+        }
+        val estimate = Estimate(bestOrientation.toFloat(), bestScale, bestX to bestY)
+        return Result(estimate, combinations, duration)
     }
 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -84,6 +84,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val gradientMin by vm.gradientMin.collectAsState()
     val mps by vm.measurementsPerSecond.collectAsState()
     val rps by vm.rotationsPerSecond.collectAsState()
+    val cps by vm.combinationsPerSecond.collectAsState()
+    val poseMs by vm.poseComputationMs.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -140,6 +142,8 @@ fun LidarScreen(vm: LidarViewModel) {
             }
             Text("Measurements/s: $mps")
             Text("Rotations/s: ${"%.2f".format(rps)}")
+            Text("Pose ms: $poseMs")
+            Text("Combos/s: ${"%.2f".format(cps)}")
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Button(
                     onClick = { vm.rotate90() },
@@ -289,6 +293,8 @@ fun LidarScreen(vm: LidarViewModel) {
             }
                 Text("Measurements/s: $mps")
                 Text("Rotations/s: ${"%.2f".format(rps)}")
+                Text("Pose ms: $poseMs")
+                Text("Combos/s: ${"%.2f".format(cps)}")
                 if (showLogs) {
                     LogView(logs, modifier = Modifier.height(160.dp))
                 }

--- a/app/src/test/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimatorTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimatorTest.kt
@@ -25,7 +25,8 @@ class OccupancyPoseEstimatorTest {
             val dist = profile[worldAngle] * scale
             measurements.add(LidarMeasurement(deg.toFloat(), (dist * 1000).toInt(), 200))
         }
-        val est = OccupancyPoseEstimator.estimate(measurements, grid)!!
+        val result = OccupancyPoseEstimator.estimate(measurements, grid)
+        val est = result.estimate!!
         println("Est: $est")
         val diff = Math.abs((est.orientation - orientation + 360) % 360)
         val angularDiff = minOf(diff, 360 - diff)


### PR DESCRIPTION
## Summary
- track pose estimator combinations tried and execution time
- surface pose estimation metrics in view model and UI
- update pose estimation tests for new result format

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6898a3d13ab4832fb56f8d5e554b1400