### PR TITLE
feat(ci): auto release on label

### DIFF
--- a/.github/workflows/build_and_distribute.yml
+++ b/.github/workflows/build_and_distribute.yml
@@ -1,9 +1,14 @@
 name: Build and Distribute APK
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
 
 jobs:
   build_and_distribute:
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- trigger build and distribute workflow when a PR with `release` label is merged into `main`
- keep manual release trigger via workflow dispatch

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_689f39da1d04832faeca4f923c094b7e