### PR TITLE
Add pose input filtering toggle

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -20,6 +20,7 @@ import com.koriit.positioner.android.viewmodel.LidarViewModel
 fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val autoScale by vm.autoScale.collectAsState()
     val showLogs by vm.showLogs.collectAsState()
+    val filterPoseInput by vm.filterPoseInput.collectAsState()
     val bufferSize by vm.bufferSize.collectAsState()
     val flushInterval by vm.flushIntervalMs.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
@@ -36,6 +37,10 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = showLogs, onCheckedChange = { vm.showLogs.value = it })
             Text("Show logs")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = filterPoseInput, onCheckedChange = { vm.filterPoseInput.value = it })
+            Text("Filter pose input")
         }
         Text("Flush interval: ${flushInterval.toInt()} ms")
         SliderWithActions(

--- a/docs/pose-filtering.adoc
+++ b/docs/pose-filtering.adoc
@@ -1,0 +1,3 @@
+== Pose input filtering
+
+Enable **Filter pose input** in the settings panel to apply measurement filtering before computing pose estimates. This reduces noise in the estimator. Disable it to run pose estimation on raw lidar measurements.


### PR DESCRIPTION
## Summary
- allow enabling/disabling filtering before pose estimation
- expose "Filter pose input" checkbox in settings panel
- document pose input filtering option

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_689f4f1191f8832f807ffa9c4b9cc9f7