### PR TITLE
feat: configurable pose scoring

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -86,6 +86,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val rps by vm.rotationsPerSecond.collectAsState()
     val poseCombos by vm.poseCombinationsPerSecond.collectAsState()
     val poseMs by vm.poseEstimateMs.collectAsState()
+    val poseScore by vm.poseScore.collectAsState()
+    val poseAvg by vm.poseScoreAverage.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -144,6 +146,8 @@ fun LidarScreen(vm: LidarViewModel) {
             Text("Rotations/s: ${"%.2f".format(rps)}")
             Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
             Text("Pose time ms: $poseMs")
+            Text("Pose score: $poseScore")
+            Text("Pose avg50: ${"%.1f".format(poseAvg)}")
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Button(
                     onClick = { vm.rotate90() },
@@ -295,6 +299,8 @@ fun LidarScreen(vm: LidarViewModel) {
                 Text("Rotations/s: ${"%.2f".format(rps)}")
                 Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
                 Text("Pose time ms: $poseMs")
+                Text("Pose score: $poseScore")
+                Text("Pose avg50: ${"%.1f".format(poseAvg)}")
                 if (showLogs) {
                     LogView(logs, modifier = Modifier.height(160.dp))
                 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -28,6 +28,7 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val minDistance by vm.minDistance.collectAsState()
     val isolationDistance by vm.isolationDistance.collectAsState()
     val isolationMinNeighbours by vm.isolationMinNeighbours.collectAsState()
+    val poseMissPenalty by vm.poseMissPenalty.collectAsState()
 
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -90,6 +91,13 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
             onValueChange = { vm.bufferSize.value = it.toInt() },
             valueRange = 100f..1000f,
             onReset = { vm.resetBufferSize() }
+        )
+        Text("Pose miss penalty: ${poseMissPenalty.toInt()}")
+        SliderWithActions(
+            value = poseMissPenalty,
+            onValueChange = { vm.poseMissPenalty.value = it },
+            valueRange = 0f..5f,
+            onReset = { vm.resetPoseMissPenalty() }
         )
     }
 }

--- a/docs/pose-miss-penalty.adoc
+++ b/docs/pose-miss-penalty.adoc
@@ -1,0 +1,3 @@
+== Pose miss penalty
+
+Adjust how strongly pose estimation penalizes measurements that fall outside the floor plan. Higher values reduce the pose score when readings hit empty space, which can help mitigate obstructions. The default of 0 applies no penalty.


### PR DESCRIPTION
## Summary
- allow penalizing pose scores when lidar hits empty space
- track pose score metrics and expose miss penalty tuning
- document pose miss penalty setting

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_689f655463c0832f9a4f2a32a7d04956