### PR TITLE
Add JSON import/export for settings

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -1,10 +1,13 @@
 package com.koriit.positioner.android.ui
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -13,6 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import com.koriit.positioner.android.ui.SliderWithActions
 import com.koriit.positioner.android.viewmodel.LidarViewModel
 
@@ -30,7 +34,19 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val isolationMinNeighbours by vm.isolationMinNeighbours.collectAsState()
     val poseMissPenalty by vm.poseMissPenalty.collectAsState()
 
+    val context = LocalContext.current
+    val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
+        uri?.let { vm.exportSettings(it, context) }
+    }
+    val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri?.let { vm.importSettings(it, context) }
+    }
+
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Button(onClick = { exportLauncher.launch("settings.json") }) { Text("Export Settings") }
+            Button(onClick = { importLauncher.launch(arrayOf("application/json")) }) { Text("Import Settings") }
+        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
             Text("Auto scale")

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -1,0 +1,21 @@
+package com.koriit.positioner.android.viewmodel
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Serializable container for user configurable settings.
+ */
+@Serializable
+data class LidarSettings(
+    val autoScale: Boolean = true,
+    val showLogs: Boolean = false,
+    val filterPoseInput: Boolean = true,
+    val bufferSize: Int = LidarViewModel.DEFAULT_BUFFER_SIZE,
+    val flushIntervalMs: Float = LidarViewModel.DEFAULT_FLUSH_INTERVAL_MS,
+    val confidenceThreshold: Float = LidarViewModel.DEFAULT_CONFIDENCE_THRESHOLD,
+    val gradientMin: Float = LidarViewModel.DEFAULT_GRADIENT_MIN,
+    val minDistance: Float = LidarViewModel.DEFAULT_MIN_DISTANCE,
+    val isolationDistance: Float = LidarViewModel.DEFAULT_ISOLATION_DISTANCE,
+    val isolationMinNeighbours: Int = LidarViewModel.DEFAULT_MIN_NEIGHBOURS,
+    val poseMissPenalty: Float = LidarViewModel.DEFAULT_POSE_MISS_PENALTY,
+)

--- a/docs/settings-import-export.adoc
+++ b/docs/settings-import-export.adoc
@@ -1,0 +1,3 @@
+= Settings import and export
+
+The settings panel now includes buttons to save the current configuration to a JSON file or load values from one. This allows sharing or restoring application preferences.


### PR DESCRIPTION
## Summary
- add UI controls to export or import current settings
- support JSON serialization of settings in view model
- document settings transfer feature

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a09e40be78832fb9774fd0405405ea