### PR TITLE
Add occupancy grid overlay and pose reuse settings

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
@@ -12,6 +13,7 @@ import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
+import com.koriit.positioner.android.localization.OccupancyGrid
 import kotlin.math.min
 
 /**
@@ -32,6 +34,8 @@ fun LidarPlot(
     measurementOrientation: Float = 0f,
     planScale: Float = 1f,
     userPosition: Pair<Float, Float>? = null,
+    occupancyGrid: OccupancyGrid? = null,
+    showOccupancyGrid: Boolean = false,
 ) {
     Canvas(modifier = modifier) {
         val points = measurements.map { m ->
@@ -81,6 +85,18 @@ fun LidarPlot(
         }
 
         translate(left = center.x, top = center.y) {
+            if (showOccupancyGrid && occupancyGrid != null) {
+                occupancyGrid.occupiedCells().forEach { cell ->
+                    var x0 = (cell.x - ux) * planScale
+                    var y0 = (cell.y - uy) * planScale
+                    val cs = cell.size * planScale
+                    drawRect(
+                        color = Color.LightGray.copy(alpha = 0.5f),
+                        topLeft = Offset(x0 * scale, -(y0 + cs) * scale),
+                        size = Size(cs * scale, cs * scale)
+                    )
+                }
+            }
             floorPlan.forEach { polygon ->
                 for (i in 0 until polygon.size - 1) {
                     var (x1, y1) = polygon[i]

--- a/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyGrid.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyGrid.kt
@@ -39,6 +39,27 @@ class OccupancyGrid private constructor(
         return isOccupied(root, originX, originY, treeSize, x, y)
     }
 
+    data class Cell(val x: Float, val y: Float, val size: Float)
+
+    fun occupiedCells(): List<Cell> {
+        val result = mutableListOf<Cell>()
+        fun traverse(node: Node, x0: Float, y0: Float, size: Float) {
+            when (node) {
+                Node.Empty -> {}
+                Node.Full -> result.add(Cell(x0, y0, size))
+                is Node.Quad -> {
+                    val half = size / 2
+                    traverse(node.nw, x0, y0 + half, half)
+                    traverse(node.ne, x0 + half, y0 + half, half)
+                    traverse(node.sw, x0, y0, half)
+                    traverse(node.se, x0 + half, y0, half)
+                }
+            }
+        }
+        traverse(root, originX, originY, treeSize)
+        return result
+    }
+
     private fun isOccupied(node: Node, x0: Float, y0: Float, size: Float, x: Float, y: Float): Boolean {
         return when (node) {
             Node.Empty -> false

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -67,6 +67,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val measurementOrientation by vm.measurementOrientation.collectAsState()
     val planScale by vm.planScale.collectAsState()
     val userPosition by vm.userPosition.collectAsState()
+    val showGrid by vm.showOccupancyGrid.collectAsState()
+    val occupancyGrid by vm.occupancyGridState.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val saveLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -123,6 +125,8 @@ fun LidarScreen(vm: LidarViewModel) {
                     measurementOrientation = measurementOrientation,
                     planScale = planScale,
                     userPosition = userPosition,
+                    occupancyGrid = occupancyGrid,
+                    showOccupancyGrid = showGrid,
                 )
                 if (loading) {
                     Column(
@@ -216,6 +220,8 @@ fun LidarScreen(vm: LidarViewModel) {
                     measurementOrientation = measurementOrientation,
                     planScale = planScale,
                     userPosition = userPosition,
+                    occupancyGrid = occupancyGrid,
+                    showOccupancyGrid = showGrid,
                 )
                 if (loading) {
                     Column(

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -33,6 +33,9 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val isolationDistance by vm.isolationDistance.collectAsState()
     val isolationMinNeighbours by vm.isolationMinNeighbours.collectAsState()
     val poseMissPenalty by vm.poseMissPenalty.collectAsState()
+    val showGrid by vm.showOccupancyGrid.collectAsState()
+    val gridCellSize by vm.gridCellSize.collectAsState()
+    val useLastPose by vm.useLastPose.collectAsState()
 
     val context = LocalContext.current
     val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
@@ -58,6 +61,14 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = filterPoseInput, onCheckedChange = { vm.filterPoseInput.value = it })
             Text("Filter pose input")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = showGrid, onCheckedChange = { vm.showOccupancyGrid.value = it })
+            Text("Show occupancy grid")
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = useLastPose, onCheckedChange = { vm.useLastPose.value = it })
+            Text("Use last pose")
         }
         Text("Flush interval: ${flushInterval.toInt()} ms")
         SliderWithActions(
@@ -100,6 +111,13 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
             onValueChange = { vm.isolationMinNeighbours.value = it.toInt() },
             valueRange = 0f..10f,
             onReset = { vm.resetIsolationMinNeighbours() }
+        )
+        Text("Grid cell size: ${"%.2f".format(gridCellSize)} m")
+        SliderWithActions(
+            value = gridCellSize,
+            onValueChange = { vm.updateGridCellSize(it) },
+            valueRange = 0.05f..0.5f,
+            onReset = { vm.resetGridCellSize() }
         )
         Text("Buffer size: $bufferSize")
         SliderWithActions(

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -18,4 +18,7 @@ data class LidarSettings(
     val isolationDistance: Float = LidarViewModel.DEFAULT_ISOLATION_DISTANCE,
     val isolationMinNeighbours: Int = LidarViewModel.DEFAULT_MIN_NEIGHBOURS,
     val poseMissPenalty: Float = LidarViewModel.DEFAULT_POSE_MISS_PENALTY,
+    val showOccupancyGrid: Boolean = false,
+    val gridCellSize: Float = LidarViewModel.DEFAULT_GRID_CELL_SIZE,
+    val useLastPose: Boolean = false,
 )

--- a/docs/last-pose.adoc
+++ b/docs/last-pose.adoc
@@ -1,0 +1,3 @@
+== Last pose reuse
+
+Pose estimation can be biased towards the most recent successful result. Enabling **Use last pose** restricts the search to orientations near the previous estimate, which reduces jitter and speeds up calculations when measurements remain stable.

--- a/docs/occupancy-grid.adoc
+++ b/docs/occupancy-grid.adoc
@@ -1,0 +1,7 @@
+== Occupancy grid
+
+The settings panel includes an option to overlay the occupancy grid on the LiDAR canvas. When **Show occupancy grid** is enabled, wall cells from the quadtree map are drawn on top of the plot so the relationship between measurements and the map can be inspected.
+
+=== Cell size
+
+Use the **Grid cell size** slider to control how coarse the grid is. Smaller values provide finer detail but require more processing while larger values are faster but less precise.


### PR DESCRIPTION
## Summary
- Allow overlaying the occupancy grid on the LiDAR canvas with adjustable cell size
- Provide option to seed pose estimation with the last best pose
- Document new occupancy grid and pose reuse settings

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a23df0b454832fa276f4e792e472d0