### PR TITLE
Consolidate settings actions and improve layout

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -6,14 +6,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import android.content.res.Configuration
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -80,6 +73,12 @@ fun LidarScreen(vm: LidarViewModel) {
     val floorPlanLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
         if (uris.isNotEmpty()) vm.loadFloorPlan(uris, context)
     }
+    val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
+        uri?.let { vm.exportSettings(it, context) }
+    }
+    val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri?.let { vm.importSettings(it, context) }
+    }
 
     var showSettings by remember { mutableStateOf(false) }
 
@@ -98,6 +97,8 @@ fun LidarScreen(vm: LidarViewModel) {
             val replaying by vm.replayMode.collectAsState()
             Row(modifier = Modifier.fillMaxWidth()) {
                 Button(onClick = { showSettings = !showSettings }) { Text("Settings") }
+                Button(onClick = { importLauncher.launch(arrayOf("application/json")) }) { Text("Import") }
+                Button(onClick = { exportLauncher.launch("settings.json") }) { Text("Export") }
             }
             if (showSettings) {
                 SettingsPanel(
@@ -146,12 +147,18 @@ fun LidarScreen(vm: LidarViewModel) {
                     }
                 }
             }
-            Text("Measurements/s: $mps")
-            Text("Rotations/s: ${"%.2f".format(rps)}")
-            Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
-            Text("Pose time ms: $poseMs")
-            Text("Pose score: $poseScore")
-            Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Measurements/s: $mps")
+                    Text("Rotations/s: ${"%.2f".format(rps)}")
+                    Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Pose time ms: $poseMs")
+                    Text("Pose score: $poseScore")
+                    Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                }
+            }
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Button(
                     onClick = { vm.rotate90() },
@@ -249,13 +256,13 @@ fun LidarScreen(vm: LidarViewModel) {
             ) {
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Button(onClick = { showSettings = !showSettings }) { Text("Settings") }
+                    Button(onClick = { importLauncher.launch(arrayOf("application/json")) }) { Text("Import") }
+                    Button(onClick = { exportLauncher.launch("settings.json") }) { Text("Export") }
                 }
                 if (showSettings) {
                     SettingsPanel(
                         vm,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f)
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -301,12 +308,18 @@ fun LidarScreen(vm: LidarViewModel) {
             if (replaying) {
                 ReplayControls(vm)
             }
-                Text("Measurements/s: $mps")
-                Text("Rotations/s: ${"%.2f".format(rps)}")
-                Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
-                Text("Pose time ms: $poseMs")
-                Text("Pose score: $poseScore")
-                Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Measurements/s: $mps")
+                        Text("Rotations/s: ${"%.2f".format(rps)}")
+                        Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Pose time ms: $poseMs")
+                        Text("Pose score: $poseScore")
+                        Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                    }
+                }
                 if (showLogs) {
                     LogView(logs, modifier = Modifier.height(160.dp))
                 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -1,13 +1,9 @@
 package com.koriit.positioner.android.ui
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -16,7 +12,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import com.koriit.positioner.android.ui.SliderWithActions
 import com.koriit.positioner.android.viewmodel.LidarViewModel
 
@@ -37,19 +32,7 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val gridCellSize by vm.gridCellSize.collectAsState()
     val useLastPose by vm.useLastPose.collectAsState()
 
-    val context = LocalContext.current
-    val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
-        uri?.let { vm.exportSettings(it, context) }
-    }
-    val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-        uri?.let { vm.importSettings(it, context) }
-    }
-
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
-        Row(modifier = Modifier.fillMaxWidth()) {
-            Button(onClick = { exportLauncher.launch("settings.json") }) { Text("Export Settings") }
-            Button(onClick = { importLauncher.launch(arrayOf("application/json")) }) { Text("Import Settings") }
-        }
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
             Text("Auto scale")


### PR DESCRIPTION
## Summary
- Move settings import/export actions beside the main Settings button with shorter labels
- Ensure settings panel shows in landscape mode
- Arrange runtime stats into two columns for better spacing

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a4be84f8c4832fb405c95f584c5fca