### PR TITLE
Add algorithm-specific tuning parameters and restructure settings panel

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -2,6 +2,8 @@ package com.koriit.positioner.android.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
@@ -10,7 +12,8 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Slider
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -21,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.koriit.positioner.android.localization.PoseAlgorithm
 import com.koriit.positioner.android.ui.SliderWithActions
 import com.koriit.positioner.android.viewmodel.LidarViewModel
@@ -43,8 +47,15 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val gridCellSize by vm.gridCellSize.collectAsState()
     val useLastPose by vm.useLastPose.collectAsState()
     val poseAlgorithm by vm.poseAlgorithm.collectAsState()
+    val occupancyOrientationStep by vm.occupancyOrientationStep.collectAsState()
+    val occupancyScaleMin by vm.occupancyScaleMin.collectAsState()
+    val occupancyScaleMax by vm.occupancyScaleMax.collectAsState()
+    val occupancyScaleStep by vm.occupancyScaleStep.collectAsState()
+    val particleCount by vm.particleCount.collectAsState()
+    val particleIterations by vm.particleIterations.collectAsState()
 
     Column(modifier = modifier.verticalScroll(rememberScrollState())) {
+        Text("Display", style = MaterialTheme.typography.titleMedium)
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = autoScale, onCheckedChange = { vm.autoScale.value = it })
             Text("Auto scale")
@@ -54,13 +65,74 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
             Text("Show logs")
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(checked = filterPoseInput, onCheckedChange = { vm.filterPoseInput.value = it })
-            Text("Filter pose input")
-        }
-        Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = showGrid, onCheckedChange = { vm.showOccupancyGrid.value = it })
             Text("Show occupancy grid")
         }
+        Divider()
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text("LiDAR", style = MaterialTheme.typography.titleMedium)
+        Text("Flush interval: ${flushInterval.toInt()} ms")
+        SliderWithActions(
+            value = flushInterval,
+            onValueChange = { vm.flushIntervalMs.value = it },
+            valueRange = 50f..1000f,
+            onReset = { vm.resetFlushInterval() }
+        )
+        Text("Buffer size: $bufferSize")
+        SliderWithActions(
+            value = bufferSize.toFloat(),
+            onValueChange = { vm.bufferSize.value = it.toInt() },
+            valueRange = 100f..1000f,
+            onReset = { vm.resetBufferSize() }
+        )
+        Divider()
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text("Filtering", style = MaterialTheme.typography.titleMedium)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = filterPoseInput, onCheckedChange = { vm.filterPoseInput.value = it })
+            Text("Filter pose input")
+        }
+        Text("Confidence threshold: ${confidence.toInt()}")
+        SliderWithActions(
+            value = confidence,
+            onValueChange = { vm.confidenceThreshold.value = it },
+            valueRange = 0f..255f,
+            onReset = { vm.resetConfidenceThreshold() }
+        )
+        Text("Color gradient min: ${gradientMin.toInt()}")
+        SliderWithActions(
+            value = gradientMin,
+            onValueChange = { vm.gradientMin.value = it },
+            valueRange = 0f..255f,
+            onReset = { vm.resetGradientMin() }
+        )
+        Text("Min distance: ${"%.2f".format(minDistance)} m")
+        SliderWithActions(
+            value = minDistance,
+            onValueChange = { vm.minDistance.value = it },
+            valueRange = 0f..2f,
+            onReset = { vm.resetMinDistance() }
+        )
+        Text("Isolation distance: ${"%.2f".format(isolationDistance)} m")
+        SliderWithActions(
+            value = isolationDistance,
+            onValueChange = { vm.isolationDistance.value = it },
+            valueRange = 0f..5f,
+            onReset = { vm.resetIsolationDistance() }
+        )
+        Text("Isolation neighbours: $isolationMinNeighbours")
+        SliderWithActions(
+            value = isolationMinNeighbours.toFloat(),
+            onValueChange = { vm.isolationMinNeighbours.value = it.toInt() },
+            valueRange = 0f..10f,
+            onReset = { vm.resetIsolationMinNeighbours() }
+        )
+        Divider()
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text("Pose estimation", style = MaterialTheme.typography.titleMedium)
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = useLastPose, onCheckedChange = { vm.useLastPose.value = it })
             Text("Use last pose")
@@ -87,47 +159,12 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
                 }
             }
         }
-        Text("Flush interval: ${flushInterval.toInt()} ms")
+        Text("Pose miss penalty: ${poseMissPenalty.toInt()}")
         SliderWithActions(
-            value = flushInterval,
-            onValueChange = { vm.flushIntervalMs.value = it },
-            valueRange = 50f..1000f,
-            onReset = { vm.resetFlushInterval() }
-        )
-        Text("Color gradient min: ${gradientMin.toInt()}")
-        SliderWithActions(
-            value = gradientMin,
-            onValueChange = { vm.gradientMin.value = it },
-            valueRange = 0f..255f,
-            onReset = { vm.resetGradientMin() }
-        )
-        Text("Confidence threshold: ${confidence.toInt()}")
-        SliderWithActions(
-            value = confidence,
-            onValueChange = { vm.confidenceThreshold.value = it },
-            valueRange = 0f..255f,
-            onReset = { vm.resetConfidenceThreshold() }
-        )
-        Text("Min distance: ${"%.2f".format(minDistance)} m")
-        SliderWithActions(
-            value = minDistance,
-            onValueChange = { vm.minDistance.value = it },
-            valueRange = 0f..2f,
-            onReset = { vm.resetMinDistance() }
-        )
-        Text("Isolation distance: ${"%.2f".format(isolationDistance)} m")
-        SliderWithActions(
-            value = isolationDistance,
-            onValueChange = { vm.isolationDistance.value = it },
+            value = poseMissPenalty,
+            onValueChange = { vm.poseMissPenalty.value = it },
             valueRange = 0f..5f,
-            onReset = { vm.resetIsolationDistance() }
-        )
-        Text("Isolation neighbours: $isolationMinNeighbours")
-        SliderWithActions(
-            value = isolationMinNeighbours.toFloat(),
-            onValueChange = { vm.isolationMinNeighbours.value = it.toInt() },
-            valueRange = 0f..10f,
-            onReset = { vm.resetIsolationMinNeighbours() }
+            onReset = { vm.resetPoseMissPenalty() }
         )
         Text("Grid cell size: ${"%.2f".format(gridCellSize)} m")
         SliderWithActions(
@@ -136,19 +173,60 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
             valueRange = 0.05f..0.5f,
             onReset = { vm.resetGridCellSize() }
         )
-        Text("Buffer size: $bufferSize")
-        SliderWithActions(
-            value = bufferSize.toFloat(),
-            onValueChange = { vm.bufferSize.value = it.toInt() },
-            valueRange = 100f..1000f,
-            onReset = { vm.resetBufferSize() }
-        )
-        Text("Pose miss penalty: ${poseMissPenalty.toInt()}")
-        SliderWithActions(
-            value = poseMissPenalty,
-            onValueChange = { vm.poseMissPenalty.value = it },
-            valueRange = 0f..5f,
-            onReset = { vm.resetPoseMissPenalty() }
-        )
+
+        when (poseAlgorithm) {
+            PoseAlgorithm.OCCUPANCY -> {
+                Divider()
+                Spacer(modifier = Modifier.height(8.dp))
+                Text("Occupancy grid", style = MaterialTheme.typography.titleMedium)
+                Text("Orientation step: $occupancyOrientationStep°")
+                SliderWithActions(
+                    value = occupancyOrientationStep.toFloat(),
+                    onValueChange = { vm.occupancyOrientationStep.value = it.toInt() },
+                    valueRange = 1f..45f,
+                    onReset = { vm.resetOccupancyOrientationStep() }
+                )
+                Text("Scale min: ${"%.2f".format(occupancyScaleMin)}")
+                SliderWithActions(
+                    value = occupancyScaleMin,
+                    onValueChange = { vm.occupancyScaleMin.value = it },
+                    valueRange = 0.5f..1f,
+                    onReset = { vm.resetOccupancyScaleMin() }
+                )
+                Text("Scale max: ${"%.2f".format(occupancyScaleMax)}")
+                SliderWithActions(
+                    value = occupancyScaleMax,
+                    onValueChange = { vm.occupancyScaleMax.value = it },
+                    valueRange = 1f..1.5f,
+                    onReset = { vm.resetOccupancyScaleMax() }
+                )
+                Text("Scale step: ${"%.2f".format(occupancyScaleStep)}")
+                SliderWithActions(
+                    value = occupancyScaleStep,
+                    onValueChange = { vm.occupancyScaleStep.value = it },
+                    valueRange = 0.01f..0.2f,
+                    onReset = { vm.resetOccupancyScaleStep() }
+                )
+            }
+            PoseAlgorithm.PARTICLE -> {
+                Divider()
+                Spacer(modifier = Modifier.height(8.dp))
+                Text("Particle filter", style = MaterialTheme.typography.titleMedium)
+                Text("Particles: $particleCount")
+                SliderWithActions(
+                    value = particleCount.toFloat(),
+                    onValueChange = { vm.particleCount.value = it.toInt() },
+                    valueRange = 100f..1000f,
+                    onReset = { vm.resetParticleCount() }
+                )
+                Text("Iterations: $particleIterations")
+                SliderWithActions(
+                    value = particleIterations.toFloat(),
+                    onValueChange = { vm.particleIterations.value = it.toInt() },
+                    valueRange = 1f..20f,
+                    onReset = { vm.resetParticleIterations() }
+                )
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -23,4 +23,10 @@ data class LidarSettings(
     val gridCellSize: Float = LidarViewModel.DEFAULT_GRID_CELL_SIZE,
     val useLastPose: Boolean = false,
     val poseAlgorithm: PoseAlgorithm = PoseAlgorithm.OCCUPANCY,
+    val occupancyOrientationStep: Int = LidarViewModel.DEFAULT_OCCUPANCY_ORIENTATION_STEP,
+    val occupancyScaleMin: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_MIN,
+    val occupancyScaleMax: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_MAX,
+    val occupancyScaleStep: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_STEP,
+    val particleCount: Int = LidarViewModel.DEFAULT_PARTICLE_COUNT,
+    val particleIterations: Int = LidarViewModel.DEFAULT_PARTICLE_ITERATIONS,
 )

--- a/docs/occupancy-orientation-step.adoc
+++ b/docs/occupancy-orientation-step.adoc
@@ -1,0 +1,3 @@
+== Occupancy orientation step
+
+Controls the angular resolution used when scanning orientations during occupancy grid search. Smaller steps improve accuracy at the cost of more computations.

--- a/docs/occupancy-scale-range.adoc
+++ b/docs/occupancy-scale-range.adoc
@@ -1,0 +1,3 @@
+== Occupancy scale range
+
+Sets minimum and maximum scale factors explored by the occupancy grid search. Adjust to cover expected plan scaling variations.

--- a/docs/occupancy-scale-step.adoc
+++ b/docs/occupancy-scale-step.adoc
@@ -1,0 +1,3 @@
+== Occupancy scale step
+
+Defines the increment between tested scale factors in the occupancy grid search. Finer steps improve precision but require more computation.

--- a/docs/particle-count.adoc
+++ b/docs/particle-count.adoc
@@ -1,0 +1,3 @@
+== Particle count
+
+Specifies how many particles are used in the particle filter. More particles improve convergence but increase computation time.

--- a/docs/particle-iterations.adoc
+++ b/docs/particle-iterations.adoc
@@ -1,0 +1,3 @@
+== Particle iterations
+
+Number of refinement passes performed by the particle filter. Additional iterations can improve accuracy at the expense of speed.


### PR DESCRIPTION
## Summary
- Add occupancy grid and particle filter tuning parameters to Lidar settings and model
- Organize settings panel into logical sections with algorithm-specific controls
- Document new tuning options for fine-grained pose estimation configuration

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a7843e7408832faf88f2488feefc18