### PR TITLE
Track filtered measurements and show plan coords

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -138,7 +138,14 @@ fun LidarPlot(
         }
 
         // Draw confidence indicators
-        drawConfidenceIndicators(confidenceStats, size, confidenceThreshold, measurements.size)
+        drawConfidenceIndicators(
+            confidenceStats,
+            size,
+            confidenceThreshold,
+            measurements.size,
+            floorPlan.isNotEmpty(),
+            userPosition,
+        )
     }
 }
 
@@ -146,8 +153,10 @@ private fun DrawScope.drawConfidenceIndicators(
     confidenceStats: Triple<Int, Int, Double>,
     size: androidx.compose.ui.geometry.Size,
     confidenceThreshold: Int,
-    totalMeasurementsCount: Int
-) {
+    totalMeasurementsCount: Int,
+    hasFloorPlan: Boolean,
+    userPosition: Pair<Float, Float>?,
+ ) {
     val (minConf, maxConf, avgConf) = confidenceStats
 
     drawIntoCanvas { canvas ->
@@ -246,22 +255,44 @@ private fun DrawScope.drawConfidenceIndicators(
             paint
         )
 
-        // Confidence threshold (bottom-right)
+        // Confidence threshold or position (bottom-right)
         val thresholdWidth = 150.dp.toPx()
-        canvas.nativeCanvas.drawRect(
-            size.width - textPadding - thresholdWidth,
-            size.height - textPadding - 40.dp.toPx(),
-            size.width - textPadding,
-            size.height - textPadding,
-            bgPaint
-        )
-
-        canvas.nativeCanvas.drawText(
-            "Threshold: $confidenceThreshold",
-            size.width - textPadding - thresholdWidth + 5.dp.toPx(),
-            size.height - textPadding - 20.dp.toPx(),
-            paint
-        )
+        if (hasFloorPlan && userPosition != null) {
+            val (ux, uy) = userPosition
+            canvas.nativeCanvas.drawRect(
+                size.width - textPadding - thresholdWidth,
+                size.height - textPadding - 60.dp.toPx(),
+                size.width - textPadding,
+                size.height - textPadding,
+                bgPaint
+            )
+            canvas.nativeCanvas.drawText(
+                "X: ${"%.2f".format(ux)}",
+                size.width - textPadding - thresholdWidth + 5.dp.toPx(),
+                size.height - textPadding - 40.dp.toPx(),
+                paint
+            )
+            canvas.nativeCanvas.drawText(
+                "Y: ${"%.2f".format(uy)}",
+                size.width - textPadding - thresholdWidth + 5.dp.toPx(),
+                size.height - textPadding - 20.dp.toPx(),
+                paint
+            )
+        } else {
+            canvas.nativeCanvas.drawRect(
+                size.width - textPadding - thresholdWidth,
+                size.height - textPadding - 40.dp.toPx(),
+                size.width - textPadding,
+                size.height - textPadding,
+                bgPaint
+            )
+            canvas.nativeCanvas.drawText(
+                "Threshold: $confidenceThreshold",
+                size.width - textPadding - thresholdWidth + 5.dp.toPx(),
+                size.height - textPadding - 20.dp.toPx(),
+                paint
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
@@ -93,7 +93,7 @@ object OccupancyPoseEstimator {
         val gridMaxX = grid.originX + grid.width * grid.cellSize
         val gridMaxY = grid.originY + grid.height * grid.cellSize
 
-        val orientations = initial?.let { orientAround(it.orientation.toInt(), 45, orientationStep) }
+        val orientations = initial?.let { orientAround(it.orientation.toInt(), 90, orientationStep) }
             ?: (0 until 360 step orientationStep).toList()
         val orientationTrig = orientations.map { orient ->
             orient to (COS_TABLE[orient * 10] to SIN_TABLE[orient * 10])

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -89,6 +89,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val poseMs by vm.poseEstimateMs.collectAsState()
     val poseScore by vm.poseScore.collectAsState()
     val poseAvg by vm.poseScoreAverage.collectAsState()
+    val filteredCount by vm.filteredMeasurements.collectAsState()
+    val filteredPct by vm.filteredPercentage.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -152,6 +154,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     Text("Measurements/s: $mps")
                     Text("Rotations/s: ${"%.2f".format(rps)}")
                     Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
+                    Text("Filtered: $filteredCount (${"%.1f".format(filteredPct)}%)")
                 }
                 Column(modifier = Modifier.weight(1f)) {
                     Text("Pose time ms: $poseMs")
@@ -313,6 +316,7 @@ fun LidarScreen(vm: LidarViewModel) {
                         Text("Measurements/s: $mps")
                         Text("Rotations/s: ${"%.2f".format(rps)}")
                         Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
+                        Text("Filtered: $filteredCount (${"%.1f".format(filteredPct)}%)")
                     }
                     Column(modifier = Modifier.weight(1f)) {
                         Text("Pose time ms: $poseMs")

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -21,7 +21,7 @@ data class LidarSettings(
     val poseMissPenalty: Float = LidarViewModel.DEFAULT_POSE_MISS_PENALTY,
     val showOccupancyGrid: Boolean = false,
     val gridCellSize: Float = LidarViewModel.DEFAULT_GRID_CELL_SIZE,
-    val useLastPose: Boolean = false,
+    val useLastPose: Boolean = true,
     val poseAlgorithm: PoseAlgorithm = PoseAlgorithm.OCCUPANCY,
     val occupancyOrientationStep: Int = LidarViewModel.DEFAULT_OCCUPANCY_ORIENTATION_STEP,
     val occupancyScaleMin: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_MIN,

--- a/docs/last-pose.adoc
+++ b/docs/last-pose.adoc
@@ -1,3 +1,3 @@
 == Last pose reuse
 
-Pose estimation can be biased towards the most recent successful result. Enabling **Use last pose** restricts the search to orientations near the previous estimate, which reduces jitter and speeds up calculations when measurements remain stable.
+Pose estimation can be biased towards the most recent successful result. Enabling **Use last pose** restricts the search to orientations within ±90° of the previous estimate, which reduces jitter and speeds up calculations when measurements remain stable.


### PR DESCRIPTION
## Summary
- display count and percentage of filtered LiDAR measurements
- show user position coordinates when a floor plan is loaded
- enable last pose reuse by default and search ±90° around it

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a7961536d8832fb59d072cbc3cf2ad