### PR TITLE
feat: flush buffer on rotation

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -37,6 +37,7 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val filterPoseInput by vm.filterPoseInput.collectAsState()
     val bufferSize by vm.bufferSize.collectAsState()
     val flushInterval by vm.flushIntervalMs.collectAsState()
+    val matchRotation by vm.matchRotation.collectAsState()
     val confidence by vm.confidenceThreshold.collectAsState()
     val gradientMin by vm.gradientMin.collectAsState()
     val minDistance by vm.minDistance.collectAsState()
@@ -72,19 +73,25 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
         Spacer(modifier = Modifier.height(8.dp))
 
         Text("LiDAR", style = MaterialTheme.typography.titleMedium)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = matchRotation, onCheckedChange = { vm.matchRotation.value = it })
+            Text("Match buffer to rotation")
+        }
         Text("Flush interval: ${flushInterval.toInt()} ms")
         SliderWithActions(
             value = flushInterval,
             onValueChange = { vm.flushIntervalMs.value = it },
             valueRange = 50f..1000f,
-            onReset = { vm.resetFlushInterval() }
+            onReset = { vm.resetFlushInterval() },
+            enabled = !matchRotation,
         )
         Text("Buffer size: $bufferSize")
         SliderWithActions(
             value = bufferSize.toFloat(),
             onValueChange = { vm.bufferSize.value = it.toInt() },
             valueRange = 100f..1000f,
-            onReset = { vm.resetBufferSize() }
+            onReset = { vm.resetBufferSize() },
+            enabled = !matchRotation,
         )
         Divider()
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SliderWithActions.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SliderWithActions.kt
@@ -18,22 +18,24 @@ fun SliderWithActions(
     onValueChange: (Float) -> Unit,
     valueRange: ClosedFloatingPointRange<Float>,
     onReset: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     Row(modifier = modifier.fillMaxWidth()) {
-        IconButton(onClick = { onValueChange(valueRange.start) }) {
+        IconButton(onClick = { onValueChange(valueRange.start) }, enabled = enabled) {
             Icon(Icons.Filled.FirstPage, contentDescription = "Min")
         }
         Slider(
             value = value,
             onValueChange = onValueChange,
             valueRange = valueRange,
+            enabled = enabled,
             modifier = Modifier.weight(1f)
         )
-        IconButton(onClick = onReset) {
+        IconButton(onClick = onReset, enabled = enabled) {
             Icon(Icons.Filled.Refresh, contentDescription = "Reset")
         }
-        IconButton(onClick = { onValueChange(valueRange.endInclusive) }) {
+        IconButton(onClick = { onValueChange(valueRange.endInclusive) }, enabled = enabled) {
             Icon(Icons.Filled.LastPage, contentDescription = "Max")
         }
     }

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -13,6 +13,8 @@ data class LidarSettings(
     val filterPoseInput: Boolean = true,
     val bufferSize: Int = LidarViewModel.DEFAULT_BUFFER_SIZE,
     val flushIntervalMs: Float = LidarViewModel.DEFAULT_FLUSH_INTERVAL_MS,
+    /** Automatically match buffer size and flush interval to full rotations */
+    val matchRotation: Boolean = false,
     val confidenceThreshold: Float = LidarViewModel.DEFAULT_CONFIDENCE_THRESHOLD,
     val gradientMin: Float = LidarViewModel.DEFAULT_GRADIENT_MIN,
     val minDistance: Float = LidarViewModel.DEFAULT_MIN_DISTANCE,

--- a/docs/buffer-size.adoc
+++ b/docs/buffer-size.adoc
@@ -2,3 +2,5 @@
 
 The settings panel includes a slider that controls how many lidar data points are kept in memory and displayed on the plot.
 Increasing the value shows more history but uses more memory. The default is 480 points.
+
+Enabling *Match buffer to rotation* adjusts the buffer size and flush interval automatically so each flush contains one full LiDAR rotation. Data is emitted whenever the angle resets.


### PR DESCRIPTION
## Summary
- add setting to match measurement buffer to full rotations
- adapt buffer size and flush interval based on rotation speed
- document buffer option and disable controls when auto mode active
- extract duplicated buffer processing into reusable methods

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a81f624db8832f9f1bcc51f04faf10