### PR TITLE
Show pose orientation and scale in stats

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -160,6 +160,8 @@ fun LidarScreen(vm: LidarViewModel) {
                     Text("Pose time ms: $poseMs")
                     Text("Pose score: $poseScore")
                     Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                    Text("Orientation: ${"%.1f".format(measurementOrientation)}°")
+                    Text("Scale: ${"%.2f".format(planScale)}")
                 }
             }
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -322,6 +324,8 @@ fun LidarScreen(vm: LidarViewModel) {
                         Text("Pose time ms: $poseMs")
                         Text("Pose score: $poseScore")
                         Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                        Text("Orientation: ${"%.1f".format(measurementOrientation)}°")
+                        Text("Scale: ${"%.2f".format(planScale)}")
                     }
                 }
                 if (showLogs) {


### PR DESCRIPTION
## Summary
- display current pose orientation and scale in stats panel

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a9bc8dded0832f81b66e5c71d9bd5e