### PR TITLE
Reapply settings during paused replay and add buffer stepping

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/ReplayControls.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,9 +41,13 @@ fun ReplayControls(vm: LidarViewModel) {
             onReset = { vm.seekTo(0L) }
         )
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Button(onClick = { vm.seekBy(-1000) }) { Text("-1s") }
+            IconButton(onClick = { vm.stepBuffer(-1) }, enabled = !playing) {
+                Icon(Icons.Filled.SkipPrevious, contentDescription = "Previous buffer")
+            }
             Button(onClick = { vm.togglePlay() }) { Text(if (playing) "Pause" else "Play") }
-            Button(onClick = { vm.seekBy(1000) }) { Text("+1s") }
+            IconButton(onClick = { vm.stepBuffer(1) }, enabled = !playing) {
+                Icon(Icons.Filled.SkipNext, contentDescription = "Next buffer")
+            }
             IconButton(onClick = { vm.changeSpeed(0.5f) }) {
                 Icon(Icons.Filled.FastRewind, contentDescription = "Slower")
             }

--- a/docs/replay-mode.adoc
+++ b/docs/replay-mode.adoc
@@ -1,6 +1,6 @@
 == Replay mode
 
-Use the *Load* button to select a previously saved recording in JSON format. Once loaded, playback controls appear below the plot allowing you to play, pause and seek through the data. Buttons adjust speed or jump forward and backward by one second.
+Use the *Load* button to select a previously saved recording in JSON format. Once loaded, playback controls appear below the plot allowing you to play, pause and seek through the data. Buttons adjust speed or step forward and backward by one buffer at a time.
 
 Press *Exit Replay* to return to live mode. Recording or loading another file is disabled while replay is active.
 


### PR DESCRIPTION
## Summary
- Reapply LiDAR settings to the current buffer when replay is paused
- Introduce buffer-sized stepping controls for manual replay navigation
- Update replay mode docs for new controls

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68ab40d9df30832f9f98aadc3832b9ab