### PR TITLE
Add orientation span setting for occupancy estimator

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/localization/OccupancyPoseEstimator.kt
@@ -60,6 +60,8 @@ object OccupancyPoseEstimator {
      * Measurement rotation and scaling are vectorized with Multik to exploit
      * CPU SIMD instructions.
      *
+     * @param orientationStep orientation increment in degrees.
+     * @param orientationSpan half angle around [initial] orientation to search.
      * @param missPenalty penalty subtracted for each measurement that does not
      * align with an occupied cell. Higher values increase sensitivity to
      * obstructions.
@@ -68,6 +70,7 @@ object OccupancyPoseEstimator {
         measurements: List<LidarMeasurement>,
         grid: OccupancyGrid,
         orientationStep: Int = 5,
+        orientationSpan: Int = 90,
         scaleRange: ClosedFloatingPointRange<Float> = 0.8f..1.2f,
         scaleStep: Float = 0.05f,
         missPenalty: Int = 0,
@@ -93,7 +96,9 @@ object OccupancyPoseEstimator {
         val gridMaxX = grid.originX + grid.width * grid.cellSize
         val gridMaxY = grid.originY + grid.height * grid.cellSize
 
-        val orientations = initial?.let { orientAround(it.orientation.toInt(), 90, orientationStep) }
+        val orientations = initial?.let {
+            orientAround(it.orientation.toInt(), orientationSpan, orientationStep)
+        }
             ?: (0 until 360 step orientationStep).toList()
         val orientationTrig = orientations.map { orient ->
             orient to (COS_TABLE[orient * 10] to SIN_TABLE[orient * 10])

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -49,6 +49,7 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
     val useLastPose by vm.useLastPose.collectAsState()
     val poseAlgorithm by vm.poseAlgorithm.collectAsState()
     val occupancyOrientationStep by vm.occupancyOrientationStep.collectAsState()
+    val occupancyOrientationSpan by vm.occupancyOrientationSpan.collectAsState()
     val occupancyScaleMin by vm.occupancyScaleMin.collectAsState()
     val occupancyScaleMax by vm.occupancyScaleMax.collectAsState()
     val occupancyScaleStep by vm.occupancyScaleStep.collectAsState()
@@ -186,6 +187,13 @@ fun SettingsPanel(vm: LidarViewModel, modifier: Modifier = Modifier) {
                 Divider()
                 Spacer(modifier = Modifier.height(8.dp))
                 Text("Occupancy grid", style = MaterialTheme.typography.titleMedium)
+                Text("Orientation span: $occupancyOrientationSpan°")
+                SliderWithActions(
+                    value = occupancyOrientationSpan.toFloat(),
+                    onValueChange = { vm.occupancyOrientationSpan.value = it.toInt() },
+                    valueRange = 0f..180f,
+                    onReset = { vm.resetOccupancyOrientationSpan() }
+                )
                 Text("Orientation step: $occupancyOrientationStep°")
                 SliderWithActions(
                     value = occupancyOrientationStep.toFloat(),

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -25,6 +25,7 @@ data class LidarSettings(
     val gridCellSize: Float = LidarViewModel.DEFAULT_GRID_CELL_SIZE,
     val useLastPose: Boolean = true,
     val poseAlgorithm: PoseAlgorithm = PoseAlgorithm.OCCUPANCY,
+    val occupancyOrientationSpan: Int = LidarViewModel.DEFAULT_OCCUPANCY_ORIENTATION_SPAN,
     val occupancyOrientationStep: Int = LidarViewModel.DEFAULT_OCCUPANCY_ORIENTATION_STEP,
     val occupancyScaleMin: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_MIN,
     val occupancyScaleMax: Float = LidarViewModel.DEFAULT_OCCUPANCY_SCALE_MAX,

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -46,6 +46,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
         const val DEFAULT_POSE_MISS_PENALTY = 0f
         const val DEFAULT_GRID_CELL_SIZE = 0.1f
         const val DEFAULT_OCCUPANCY_ORIENTATION_STEP = 5
+        const val DEFAULT_OCCUPANCY_ORIENTATION_SPAN = 90
         const val DEFAULT_OCCUPANCY_SCALE_MIN = 0.8f
         const val DEFAULT_OCCUPANCY_SCALE_MAX = 1.2f
         const val DEFAULT_OCCUPANCY_SCALE_STEP = 0.05f
@@ -72,6 +73,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
     val useLastPose = MutableStateFlow(true)
     val poseAlgorithm = MutableStateFlow(PoseAlgorithm.OCCUPANCY)
     val occupancyOrientationStep = MutableStateFlow(DEFAULT_OCCUPANCY_ORIENTATION_STEP)
+    val occupancyOrientationSpan = MutableStateFlow(DEFAULT_OCCUPANCY_ORIENTATION_SPAN)
     val occupancyScaleMin = MutableStateFlow(DEFAULT_OCCUPANCY_SCALE_MIN)
     val occupancyScaleMax = MutableStateFlow(DEFAULT_OCCUPANCY_SCALE_MAX)
     val occupancyScaleStep = MutableStateFlow(DEFAULT_OCCUPANCY_SCALE_STEP)
@@ -132,6 +134,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 gridCellSize.map { },
                 useLastPose.map { },
                 poseAlgorithm.map { },
+                occupancyOrientationSpan.map { },
                 occupancyOrientationStep.map { },
                 occupancyScaleMin.map { },
                 occupancyScaleMax.map { },
@@ -166,6 +169,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
     fun resetBufferSize() { bufferSize.value = DEFAULT_BUFFER_SIZE }
     fun resetPoseMissPenalty() { poseMissPenalty.value = DEFAULT_POSE_MISS_PENALTY }
     fun resetGridCellSize() { gridCellSize.value = DEFAULT_GRID_CELL_SIZE; rebuildGrid() }
+    fun resetOccupancyOrientationSpan() { occupancyOrientationSpan.value = DEFAULT_OCCUPANCY_ORIENTATION_SPAN }
     fun resetOccupancyOrientationStep() { occupancyOrientationStep.value = DEFAULT_OCCUPANCY_ORIENTATION_STEP }
     fun resetOccupancyScaleMin() { occupancyScaleMin.value = DEFAULT_OCCUPANCY_SCALE_MIN }
     fun resetOccupancyScaleMax() { occupancyScaleMax.value = DEFAULT_OCCUPANCY_SCALE_MAX }
@@ -206,6 +210,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 gridCellSize = gridCellSize.value,
                 useLastPose = useLastPose.value,
                 poseAlgorithm = poseAlgorithm.value,
+                occupancyOrientationSpan = occupancyOrientationSpan.value,
                 occupancyOrientationStep = occupancyOrientationStep.value,
                 occupancyScaleMin = occupancyScaleMin.value,
                 occupancyScaleMax = occupancyScaleMax.value,
@@ -246,6 +251,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                     gridCellSize.value = it.gridCellSize
                     useLastPose.value = it.useLastPose
                     poseAlgorithm.value = it.poseAlgorithm
+                    occupancyOrientationSpan.value = it.occupancyOrientationSpan
                     occupancyOrientationStep.value = it.occupancyOrientationStep
                     occupancyScaleMin.value = it.occupancyScaleMin
                     occupancyScaleMax.value = it.occupancyScaleMax
@@ -266,6 +272,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 measurements,
                 grid,
                 orientationStep = occupancyOrientationStep.value,
+                orientationSpan = occupancyOrientationSpan.value,
                 scaleRange = occupancyScaleMin.value..occupancyScaleMax.value,
                 scaleStep = occupancyScaleStep.value,
                 missPenalty = poseMissPenalty.value.toInt(),

--- a/docs/occupancy-orientation-span.adoc
+++ b/docs/occupancy-orientation-span.adoc
@@ -1,0 +1,3 @@
+== Occupancy orientation span
+
+Defines the half-angle around the previous orientation considered during occupancy grid search. Larger spans increase robustness but require more computations.


### PR DESCRIPTION
## Summary
- make occupancy search angle configurable
- expose orientation span setting in view model and UI
- document new orientation span option

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68ab477a6c3c832facacb7385fc99789