### PR TITLE
Add selectable RANSAC line detection

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineAlgorithm.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineAlgorithm.kt
@@ -1,0 +1,21 @@
+package com.koriit.positioner.android.lidar
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Available line detection algorithms.
+ */
+@Serializable
+enum class LineAlgorithm {
+    /** Sequential clustering with linear regression. */
+    CLUSTER,
+
+    /** Random sample consensus based detection. */
+    RANSAC;
+
+    val displayName: String
+        get() = when (this) {
+            CLUSTER -> "Cluster"
+            RANSAC -> "RANSAC"
+        }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.koriit.positioner.android.localization.PoseAlgorithm
+import com.koriit.positioner.android.lidar.LineAlgorithm
 import com.koriit.positioner.android.ui.SliderWithActions
 import com.koriit.positioner.android.viewmodel.LidarViewModel
 import androidx.compose.material.icons.Icons
@@ -76,6 +77,7 @@ fun SettingsPanel(
     val lineFilterInlierFactor by vm.lineFilterInlierFactor.collectAsState()
     val lineFilterInlierMin by vm.lineFilterInlierMin.collectAsState()
     val lineFilterInlierMax by vm.lineFilterInlierMax.collectAsState()
+    val lineAlgorithm by vm.lineAlgorithm.collectAsState()
     val poseMissPenalty by vm.poseMissPenalty.collectAsState()
     val showGrid by vm.showOccupancyGrid.collectAsState()
     val gridCellSize by vm.gridCellSize.collectAsState()
@@ -191,6 +193,28 @@ fun SettingsPanel(
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(checked = detectLines, onCheckedChange = { vm.detectLines.value = it })
             Text("Detect lines")
+        }
+        var lineAlgoExpanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(expanded = lineAlgoExpanded, onExpandedChange = { lineAlgoExpanded = !lineAlgoExpanded }) {
+            TextField(
+                value = lineAlgorithm.displayName,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Line algorithm") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = lineAlgoExpanded) },
+                modifier = Modifier.menuAnchor(),
+            )
+            DropdownMenu(expanded = lineAlgoExpanded, onDismissRequest = { lineAlgoExpanded = false }) {
+                LineAlgorithm.values().forEach { option ->
+                    DropdownMenuItem(
+                        text = { Text(option.displayName) },
+                        onClick = {
+                            vm.lineAlgorithm.value = option
+                            lineAlgoExpanded = false
+                        },
+                    )
+                }
+            }
         }
         Text("Distance threshold: ${"%.2f".format(lineDistanceThreshold)} m")
         SliderWithActions(

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -1,6 +1,7 @@
 package com.koriit.positioner.android.viewmodel
 
 import com.koriit.positioner.android.localization.PoseAlgorithm
+import com.koriit.positioner.android.lidar.LineAlgorithm
 import kotlinx.serialization.Serializable
 
 /**
@@ -36,6 +37,7 @@ data class LidarSettings(
     val lineFilterInlierFactor: Float = LidarViewModel.DEFAULT_LINE_FILTER_INLIER_FACTOR,
     val lineFilterInlierMin: Int = LidarViewModel.DEFAULT_LINE_FILTER_INLIER_MIN,
     val lineFilterInlierMax: Int = LidarViewModel.DEFAULT_LINE_FILTER_INLIER_MAX,
+    val lineAlgorithm: LineAlgorithm = LineAlgorithm.CLUSTER,
     val poseMissPenalty: Float = LidarViewModel.DEFAULT_POSE_MISS_PENALTY,
     val showOccupancyGrid: Boolean = false,
     val gridCellSize: Float = LidarViewModel.DEFAULT_GRID_CELL_SIZE,

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -12,6 +12,7 @@ import com.koriit.positioner.android.lidar.LidarReader
 import com.koriit.positioner.android.lidar.MeasurementFilter
 import com.koriit.positioner.android.lidar.GeoJsonParser
 import com.koriit.positioner.android.lidar.LineDetector
+import com.koriit.positioner.android.lidar.LineAlgorithm
 import com.koriit.positioner.android.localization.OccupancyGrid
 import com.koriit.positioner.android.localization.OccupancyPoseEstimator
 import com.koriit.positioner.android.localization.ParticlePoseEstimator
@@ -99,6 +100,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
     val lineFilterInlierFactor = MutableStateFlow(DEFAULT_LINE_FILTER_INLIER_FACTOR)
     val lineFilterInlierMin = MutableStateFlow(DEFAULT_LINE_FILTER_INLIER_MIN)
     val lineFilterInlierMax = MutableStateFlow(DEFAULT_LINE_FILTER_INLIER_MAX)
+    val lineAlgorithm = MutableStateFlow(LineAlgorithm.CLUSTER)
     val lineLengthPx = MutableStateFlow(0f)
     val lineInlierPx = MutableStateFlow(0f)
     val poseMissPenalty = MutableStateFlow(DEFAULT_POSE_MISS_PENALTY)
@@ -169,6 +171,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 lineMinPoints.map { },
                 lineAngleTolerance.map { },
                 lineGapTolerance.map { },
+                lineAlgorithm.map { },
                 filterPoseInput.map { },
                 poseMissPenalty.map { },
                 gridCellSize.map { },
@@ -277,6 +280,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 lineFilterInlierFactor = lineFilterInlierFactor.value,
                 lineFilterInlierMin = lineFilterInlierMin.value,
                 lineFilterInlierMax = lineFilterInlierMax.value,
+                lineAlgorithm = lineAlgorithm.value,
                 poseMissPenalty = poseMissPenalty.value,
                 showOccupancyGrid = showOccupancyGrid.value,
                 gridCellSize = gridCellSize.value,
@@ -334,6 +338,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                     lineFilterInlierFactor.value = it.lineFilterInlierFactor
                     lineFilterInlierMin.value = it.lineFilterInlierMin
                     lineFilterInlierMax.value = it.lineFilterInlierMax
+                    lineAlgorithm.value = it.lineAlgorithm
                     poseMissPenalty.value = it.poseMissPenalty
                     showOccupancyGrid.value = it.showOccupancyGrid
                     gridCellSize.value = it.gridCellSize
@@ -532,6 +537,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
                 lineMinPoints.value,
                 lineAngleTolerance.value,
                 lineGapTolerance.value,
+                lineAlgorithm.value,
             )
             val (filteredLines, stats) = LineDetector.filterAdaptive(
                 lines,

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
@@ -4,6 +4,7 @@ import kotlin.math.atan2
 import kotlin.math.hypot
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import com.koriit.positioner.android.lidar.LineAlgorithm
 
 class LineDetectorTest {
     private fun meas(x: Float, y: Float): LidarMeasurement {
@@ -13,12 +14,25 @@ class LineDetectorTest {
     }
 
     @Test
-    fun detectsTwoLines() {
+    fun detectsTwoLinesCluster() {
         val points = mutableListOf<LidarMeasurement>()
         for (x in -10..10 step 2) {
             points.add(meas(x / 10f, 1f))
         }
-        val lines = LineDetector.detect(points, 0.2f, 3, 10f, 10f)
+        val lines = LineDetector.detect(points, 0.2f, 3, 10f, 10f, LineAlgorithm.CLUSTER)
+        assertEquals(1, lines.size)
+        assertEquals(90f, lines[0].orientation, 5f)
+        val reps = LineDetector.asMeasurements(lines)
+        assertEquals(lines[0].pointCount, reps.size)
+    }
+
+    @Test
+    fun detectsTwoLinesRansac() {
+        val points = mutableListOf<LidarMeasurement>()
+        for (x in -10..10 step 2) {
+            points.add(meas(x / 10f, 1f))
+        }
+        val lines = LineDetector.detect(points, 0.2f, 3, 10f, 10f, LineAlgorithm.RANSAC)
         assertEquals(1, lines.size)
         assertEquals(90f, lines[0].orientation, 5f)
         val reps = LineDetector.asMeasurements(lines)

--- a/docs/line-detection.adoc
+++ b/docs/line-detection.adoc
@@ -4,6 +4,14 @@ When enabled, incoming LiDAR measurements are grouped into linear features. Each
 
 The settings panel also allows toggling visualisation of raw measurements and detected lines.
 
+=== Algorithms
+
+Two algorithms are available:
+
+Cluster:: Groups consecutive measurements using linear regression. Works well on ordered data.
+
+RANSAC:: Randomly samples pairs of points to fit robust lines that ignore outliers.
+
 === Parameters
 
 Distance threshold:: Maximum perpendicular distance in metres a point may deviate from a candidate line.


### PR DESCRIPTION
## Summary
- add RANSAC-based line detector and keep existing cluster method
- expose line detection algorithm in settings and UI
- document line detection algorithms

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68bb2dfea534832f857d51587fdf9be6