### PR TITLE
Normalize line orientation across detectors

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineDetector.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineDetector.kt
@@ -39,6 +39,13 @@ object LineDetector {
         val inliersPx: Double,
     )
 
+    /** Normalize orientation in degrees to the [0, 180) range. */
+    private fun normalizeOrientation(deg: Float): Float {
+        var angle = deg % 180f
+        if (angle < 0f) angle += 180f
+        return angle
+    }
+
     /**
      * Detect line features from [measurements].
      */
@@ -133,7 +140,7 @@ object LineDetector {
             val start = Pair(refx + minT * ux, refy + minT * uy)
             val end = Pair(refx + maxT * ux, refy + maxT * uy)
             val length = hypot(end.first - start.first, end.second - start.second)
-            val orientation = (angleRad * 180f / PI).toFloat()
+            val orientation = normalizeOrientation((angleRad * 180f / PI).toFloat())
             lines.add(LineFeature(start, end, orientation, length, cluster.size))
             cluster = mutableListOf()
             reg = SimpleRegression()
@@ -225,8 +232,7 @@ object LineDetector {
             val start = Pair(refx + minT * ux, refy + minT * uy)
             val end = Pair(refx + maxT * ux, refy + maxT * uy)
             val length = hypot(end.first - start.first, end.second - start.second)
-            var orientation = (angleRad * 180f / PI).toFloat()
-            if (orientation < 0f) orientation += 180f
+            val orientation = normalizeOrientation((angleRad * 180f / PI).toFloat())
             lines.add(LineFeature(start, end, orientation, length, bestInliers.size))
             remaining.removeAll(bestInliers.toSet())
         }

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
@@ -40,6 +40,21 @@ class LineDetectorTest {
     }
 
     @Test
+    fun normalizesVerticalLineOrientation() {
+        val points = mutableListOf<LidarMeasurement>()
+        for (y in -10..10 step 2) {
+            if (y == 0) continue
+            points.add(meas(0f, y / 10f))
+        }
+        val cluster = LineDetector.detect(points, 0.2f, 3, 10f, 10f, LineAlgorithm.CLUSTER)
+        assertEquals(1, cluster.size)
+        assertEquals(0f, cluster[0].orientation, 5f)
+        val ransac = LineDetector.detect(points, 0.2f, 3, 10f, 10f, LineAlgorithm.RANSAC)
+        assertEquals(1, ransac.size)
+        assertEquals(0f, ransac[0].orientation, 5f)
+    }
+
+    @Test
     fun filtersShortLines() {
         val lines = listOf(
             LineDetector.LineFeature(Pair(0f, 0f), Pair(1f, 0f), 0f, 1f, 2),

--- a/docs/line-detection.adoc
+++ b/docs/line-detection.adoc
@@ -12,6 +12,8 @@ Cluster:: Groups consecutive measurements using linear regression. Works well on
 
 RANSAC:: Randomly samples pairs of points to fit robust lines that ignore outliers.
 
+All algorithms normalise line orientation to the [0, 180) range for consistent processing and display.
+
 === Parameters
 
 Distance threshold:: Maximum perpendicular distance in metres a point may deviate from a candidate line.


### PR DESCRIPTION
## Summary
- Normalize line orientations to [0, 180) degrees for both Cluster and RANSAC algorithms
- Add regression test for vertical line orientation
- Document orientation normalization

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68bc2c1e2bd0832f81894325cc113aec