### PR TITLE
Handle orientation wraparound

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineDetector.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LineDetector.kt
@@ -5,6 +5,7 @@ import org.apache.commons.math3.stat.regression.SimpleRegression
 import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.hypot
+import kotlin.math.min
 import kotlin.math.PI
 import kotlin.math.sin
 import kotlin.math.cos
@@ -47,6 +48,15 @@ object LineDetector {
     }
 
     /**
+     * Minimal difference between two line orientations in degrees.
+     * Orientations are directionless and wrap every 180°.
+     */
+    internal fun angleDiff180(a: Float, b: Float): Float {
+        val diff = (a - b).mod(180f)
+        return min(diff, 180f - diff)
+    }
+
+    /**
      * Detect line features from [measurements].
      */
     fun detect(
@@ -82,7 +92,7 @@ object LineDetector {
         val merged = mutableListOf<LineFeature>()
         for (line in lines) {
             val last = merged.lastOrNull()
-            if (last != null && abs(line.orientation - last.orientation) <= angleTolerance) {
+            if (last != null && angleDiff180(line.orientation, last.orientation) <= angleTolerance) {
                 val newLine = LineFeature(
                     last.start,
                     line.end,

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/LineDetectorTest.kt
@@ -77,5 +77,11 @@ class LineDetectorTest {
         assertEquals(3.0, stats.lengthPx, 0.01)
         assertEquals(10.0, stats.inliersPx, 0.01)
     }
+
+    @Test
+    fun computesOrientationDifferenceAcrossWraparound() {
+        val diff = LineDetector.angleDiff180(1f, 179f)
+        assertEquals(2f, diff, 0.0001f)
+    }
 }
 

--- a/docs/line-detection.adoc
+++ b/docs/line-detection.adoc
@@ -22,7 +22,7 @@ Minimum points:: Minimum number of measurements required to accept a line.
 
 Merge lines:: Combine adjacent lines with similar orientation. When disabled, raw segments are kept separate.
 
-Angle tolerance:: When adjacent lines differ by less than this angle (degrees) they are merged.
+Angle tolerance:: When adjacent lines differ by less than this angle (degrees) they are merged. Differences are calculated on normalised angles, so orientations near 0° and 180° compare correctly.
 
 Gap tolerance (Cluster only):: Maximum angular gap in degrees between consecutive points to still belong to the same line.
 


### PR DESCRIPTION
## Summary
- add helper to compute minimal angle difference
- use normalized angle difference when merging line segments
- document orientation wraparound handling and test it

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68bc79df6e9c832fa74bd0c5e111de0d