### PR TITLE
Enable line overlay by default

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -141,17 +141,6 @@ fun LidarPlot(
                 }
             }
 
-            if (showLines) {
-                segments.forEach { (start, end) ->
-                    drawLine(
-                        color = Color.Magenta,
-                        start = Offset(start.first * scale, -start.second * scale),
-                        end = Offset(end.first * scale, -end.second * scale),
-                        strokeWidth = 2f,
-                    )
-                }
-            }
-
             if (showMeasurements) {
                 points.forEach { (x, y, confidence) ->
                     val px = x * scale
@@ -168,6 +157,17 @@ fun LidarPlot(
                     )
 
                     drawCircle(color, radius = 3f, center = Offset(px, py))
+                }
+            }
+
+            if (showLines) {
+                segments.forEach { (start, end) ->
+                    drawLine(
+                        color = Color.Magenta,
+                        start = Offset(start.first * scale, -start.second * scale),
+                        end = Offset(end.first * scale, -end.second * scale),
+                        strokeWidth = 3f,
+                    )
                 }
             }
 

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -68,7 +68,7 @@ class LidarViewModel(private val context: Context) : ViewModel() {
         const val DEFAULT_PARTICLE_COUNT = 200
         const val DEFAULT_PARTICLE_ITERATIONS = 5
         const val DEFAULT_SHOW_MEASUREMENTS = true
-        const val DEFAULT_SHOW_LINES = false
+        const val DEFAULT_SHOW_LINES = true
     }
 
     val flushIntervalMs = MutableStateFlow(DEFAULT_FLUSH_INTERVAL_MS)


### PR DESCRIPTION
## Summary
- Draw detected lines after measurements with a thicker stroke for better visibility
- Enable line rendering by default

## Testing
- `./gradlew --console=plain tasks --no-daemon | tail -n 20`
- `./gradlew --console=plain test --no-daemon | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bd432407cc832fb62a64710ecb03fa