### PR TITLE
Stream compressed rotation sessions

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
@@ -1,0 +1,18 @@
+package com.koriit.positioner.android.recording
+
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * Single LiDAR rotation with timestamped measurements.
+ *
+ * The class is deliberately extendable; new attributes can be
+ * added in future versions without breaking serialization.
+ */
+@Serializable
+data class Rotation(
+    val measurements: List<LidarMeasurement>,
+    val start: Instant = Clock.System.now(),
+)

--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionReader.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionReader.kt
@@ -1,0 +1,62 @@
+package com.koriit.positioner.android.recording
+
+import android.content.Context
+import android.net.Uri
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import java.io.InputStream
+import java.util.zip.GZIPInputStream
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Read session recordings supporting both legacy and current formats.
+ */
+object SessionReader {
+    private val json = Json
+
+    fun read(context: Context, uri: Uri): List<Rotation> {
+        context.contentResolver.openInputStream(uri)?.use { input ->
+            return read(input)
+        }
+        return emptyList()
+    }
+
+    private fun read(input: InputStream): List<Rotation> {
+        val stream = if (isGzip(input)) GZIPInputStream(input) else input
+        val content = stream.bufferedReader().use { it.readText() }
+        val trimmed = content.trimStart()
+        return if (trimmed.startsWith("[")) {
+            // Legacy format: plain JSON array of measurements
+            val data = json.decodeFromString<List<LidarMeasurement>>(content)
+            val rotations = mutableListOf<Rotation>()
+            var current = mutableListOf<LidarMeasurement>()
+            var lastAngle: Float? = null
+            data.forEach { m ->
+                lastAngle?.let { prev ->
+                    if (m.angle < prev) {
+                        rotations.add(Rotation(current, current.first().timestamp))
+                        current = mutableListOf()
+                    }
+                }
+                current.add(m)
+                lastAngle = m.angle
+            }
+            if (current.isNotEmpty()) rotations.add(Rotation(current, current.first().timestamp))
+            rotations
+        } else {
+            // Current format: one rotation per line
+            content.lineSequence()
+                .filter { it.isNotBlank() }
+                .map { json.decodeFromString<Rotation>(it) }
+                .toList()
+        }
+    }
+
+    private fun isGzip(input: InputStream): Boolean {
+        input.mark(2)
+        val header = ByteArray(2)
+        val read = input.read(header)
+        input.reset()
+        return read == 2 && header[0] == 0x1f.toByte() && header[1] == 0x8b.toByte()
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionWriter.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionWriter.kt
@@ -1,0 +1,39 @@
+package com.koriit.positioner.android.recording
+
+import android.content.Context
+import android.net.Uri
+import java.io.Closeable
+import java.io.OutputStream
+import java.util.zip.GZIPOutputStream
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Stream session rotations into a compressed file.
+ */
+class SessionWriter private constructor(private val out: OutputStream) : Closeable {
+    private val gzip = GZIPOutputStream(out)
+    private val writer = gzip.bufferedWriter()
+
+    /**
+     * Append a rotation to the session file.
+     */
+    fun write(rotation: Rotation) {
+        val json = Json.encodeToString(rotation)
+        writer.write(json)
+        writer.newLine()
+    }
+
+    override fun close() {
+        writer.flush()
+        gzip.finish()
+        gzip.close()
+    }
+
+    companion object {
+        fun open(context: Context, uri: Uri): SessionWriter? {
+            val stream = context.contentResolver.openOutputStream(uri) ?: return null
+            return SessionWriter(stream)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -1,6 +1,5 @@
 package com.koriit.positioner.android.ui
 
-import android.content.Context
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
@@ -72,8 +71,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val inlierPercentile by vm.lineFilterInlierPercentile.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
-    val saveLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
-        uri?.let { vm.saveSession(it, context) }
+    val recordLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/gzip")) { uri ->
+        uri?.let { vm.startRecording(it, context) }
     }
     val loadLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         uri?.let { vm.loadRecording(it, context) }
@@ -188,26 +187,22 @@ fun LidarScreen(vm: LidarViewModel) {
             }
             Row(modifier = Modifier.fillMaxWidth()) {
                 Button(
-                    onClick = { vm.toggleRecording() },
+                    onClick = {
+                        if (recording) {
+                            vm.stopRecording()
+                        } else {
+                            val timestamp = Clock.System.now().toString().replace(":", "-")
+                            recordLauncher.launch("lidar-session-$timestamp.json.gz")
+                        }
+                    },
                     enabled = !replaying
                 ) {
                     Text(if (recording) "Stop Recording" else "Start Recording")
                 }
-                if (recording) {
-                    Button(onClick = { vm.clearSession() }, enabled = !replaying) { Text("Reset") }
-                    Button(
-                        onClick = {
-                            vm.toggleRecording()
-                            val timestamp = Clock.System.now().toString().replace(":", "-")
-                            saveLauncher.launch("lidar-session-$timestamp.json")
-                        },
-                        enabled = !replaying
-                    ) { Text("Save") }
-                }
             }
             Row(modifier = Modifier.fillMaxWidth()) {
                 Button(
-                    onClick = { loadLauncher.launch(arrayOf("application/json")) },
+                    onClick = { loadLauncher.launch(arrayOf("application/gzip", "application/json")) },
                     enabled = !recording && !replaying && !loading
                 ) { Text("Load") }
                 if (replaying) {
@@ -298,26 +293,22 @@ fun LidarScreen(vm: LidarViewModel) {
                 }
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Button(
-                        onClick = { vm.toggleRecording() },
+                        onClick = {
+                            if (recording) {
+                                vm.stopRecording()
+                            } else {
+                                val timestamp = Clock.System.now().toString().replace(":", "-")
+                                recordLauncher.launch("lidar-session-$timestamp.json.gz")
+                            }
+                        },
                         enabled = !replaying
                     ) {
                         Text(if (recording) "Stop Recording" else "Start Recording")
                     }
-                    if (recording) {
-                        Button(onClick = { vm.clearSession() }, enabled = !replaying) { Text("Reset") }
-                        Button(
-                            onClick = {
-                                vm.toggleRecording()
-                                val timestamp = Clock.System.now().toString().replace(":", "-")
-                                saveLauncher.launch("lidar-session-$timestamp.json")
-                            },
-                            enabled = !replaying
-                        ) { Text("Save") }
-                    }
                 }
             Row(modifier = Modifier.fillMaxWidth()) {
                 Button(
-                    onClick = { loadLauncher.launch(arrayOf("application/json")) },
+                    onClick = { loadLauncher.launch(arrayOf("application/gzip", "application/json")) },
                     enabled = !recording && !replaying && !loading
                 ) { Text("Load") }
                 if (replaying) {

--- a/docs/replay-mode.adoc
+++ b/docs/replay-mode.adoc
@@ -1,6 +1,6 @@
 == Replay mode
 
-Use the *Load* button to select a previously saved recording in JSON format. Once loaded, playback controls appear below the plot allowing you to play, pause and seek through the data. Buttons adjust speed or step forward and backward by one rotation at a time.
+Use the *Load* button to select a previously saved recording. Gzip-compressed session files and legacy JSON recordings are supported. Once loaded, playback controls appear below the plot allowing you to play, pause and seek through the data. Buttons adjust speed or step forward and backward by one rotation at a time.
 
 Press *Exit Replay* to return to live mode. Recording or loading another file is disabled while replay is active.
 

--- a/docs/session-recording.adoc
+++ b/docs/session-recording.adoc
@@ -1,0 +1,9 @@
+== Session recording
+
+Recordings are saved as gzip-compressed NDJSON files. Each line contains a JSON
+object describing a single LiDAR rotation with its measurements and start
+timestamp. The format is easily extendable so future attributes can be added
+without breaking compatibility.
+
+Older recordings stored as a plain JSON array of measurements are still
+supported and are automatically converted when loaded.


### PR DESCRIPTION
## Summary
- Stream rotations directly to a gzip-compressed NDJSON file using a new Rotation model
- Start/stop recording with early file selection and automatic legacy replay conversion
- Document new session format and update replay loading docs

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon --console=plain | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c15f299d44832f9a984dded8cdc9fc