### PR TITLE
Fix session loading crash when reading gzipped sessions

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionReader.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/SessionReader.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import com.koriit.positioner.android.lidar.LidarMeasurement
 import java.io.InputStream
 import java.util.zip.GZIPInputStream
+import kotlin.io.buffered
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
@@ -21,8 +22,9 @@ object SessionReader {
         return emptyList()
     }
 
-    private fun read(input: InputStream): List<Rotation> {
-        val stream = if (isGzip(input)) GZIPInputStream(input) else input
+    internal fun read(input: InputStream): List<Rotation> {
+        val buffered = input.buffered()
+        val stream = if (isGzip(buffered)) GZIPInputStream(buffered) else buffered
         val content = stream.bufferedReader().use { it.readText() }
         val trimmed = content.trimStart()
         return if (trimmed.startsWith("[")) {

--- a/app/src/test/kotlin/com/koriit/positioner/android/recording/SessionReaderTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/recording/SessionReaderTest.kt
@@ -1,0 +1,56 @@
+package com.koriit.positioner.android.recording
+
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.GZIPOutputStream
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SessionReaderTest {
+    @Test
+    fun `reads gzipped new format`() {
+        val rotation = Rotation(
+            measurements = listOf(
+                LidarMeasurement(10f, 100, 255),
+                LidarMeasurement(20f, 100, 255)
+            )
+        )
+        val json = Json.encodeToString(rotation)
+        val file = File.createTempFile("rotation", ".json.gz")
+        GZIPOutputStream(FileOutputStream(file)).bufferedWriter().use { writer ->
+            writer.write(json)
+            writer.newLine()
+        }
+
+        FileInputStream(file).use { stream ->
+            val result = SessionReader.read(stream)
+            assertEquals(1, result.size)
+            assertEquals(2, result.first().measurements.size)
+        }
+    }
+
+    @Test
+    fun `reads gzipped legacy format`() {
+        val measurements = listOf(
+            LidarMeasurement(10f, 100, 255),
+            LidarMeasurement(20f, 100, 255),
+            LidarMeasurement(5f, 100, 255) // triggers new rotation
+        )
+        val json = Json.encodeToString(measurements)
+        val file = File.createTempFile("legacy", ".json.gz")
+        GZIPOutputStream(FileOutputStream(file)).bufferedWriter().use { writer ->
+            writer.write(json)
+        }
+
+        FileInputStream(file).use { stream ->
+            val result = SessionReader.read(stream)
+            assertEquals(2, result.size)
+            assertEquals(2, result.first().measurements.size)
+            assertEquals(1, result.last().measurements.size)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- buffer session file streams before detecting gzip to avoid mark/reset errors
- expose `SessionReader.read(InputStream)` for tests
- add tests for reading gzipped new and legacy session formats

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68c1af04315c832f9787c751b7798cb0