### PR TITLE
Request body sensor permissions for gyro

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarViewModel.kt
@@ -572,6 +572,11 @@ class LidarViewModel(private val context: Context) : ViewModel() {
         }
     }
 
+    /**
+     * Restart gyroscope readings, typically after permissions change.
+     */
+    fun refreshGyroscope() = startGyroscope()
+
     private fun drainGyroscope(): List<GyroscopeMeasurement> = synchronized(gyroscopeBuffer) {
         val copy = gyroscopeBuffer.toList()
         gyroscopeBuffer.clear()


### PR DESCRIPTION
## Summary
- request BODY_SENSORS and HIGH_SAMPLING_RATE_SENSORS at runtime so gyroscope data can be recorded
- restart gyroscope sampling once permissions are granted

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68c1bfd5dd18832f8e9b3bd5fe0d2f82