### PR TITLE
Add gyroscope-based rotation toggle and orientation tracking

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/gyro/GyroscopeOrientationTracker.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/gyro/GyroscopeOrientationTracker.kt
@@ -1,0 +1,104 @@
+package com.koriit.positioner.android.gyro
+
+import com.koriit.positioner.android.recording.Rotation
+import kotlinx.datetime.Instant
+
+/**
+ * Utility that integrates gyroscope samples into an absolute orientation.
+ */
+class GyroscopeOrientationTracker {
+
+    private var orientationRad: Float = 0f
+    private var orientationDeg: Float = 0f
+    private var lastTimestamp: Instant? = null
+
+    /**
+     * Integrate [samples] into the internal orientation estimate.
+     *
+     * @param samples samples ordered by timestamp.
+     * @param startTimestamp optional timestamp to use for the first integration
+     * window. When not provided the tracker falls back to the previous sample
+     * time or the first element in [samples].
+     * @return normalised orientation in degrees within [-180, 180).
+     */
+    fun integrate(samples: List<GyroscopeMeasurement>, startTimestamp: Instant? = null): Float {
+        if (samples.isEmpty()) return orientationDeg
+        var previous = startTimestamp ?: lastTimestamp ?: samples.first().timestamp
+        var updated = orientationRad
+        samples.forEach { measurement ->
+            val delta = measurement.timestamp - previous
+            val deltaNs = delta.inWholeNanoseconds
+            if (deltaNs != 0L) {
+                val deltaSeconds = deltaNs / 1_000_000_000f
+                updated += measurement.z * deltaSeconds
+            }
+            previous = measurement.timestamp
+        }
+        lastTimestamp = previous
+        orientationRad = normalizeRadians(updated)
+        orientationDeg = normalizeDegrees(Math.toDegrees(orientationRad.toDouble()).toFloat())
+        return orientationDeg
+    }
+
+    /**
+     * Replace the current orientation with an absolute value.
+     */
+    fun apply(orientation: Float, lastTimestamp: Instant?) {
+        val normalized = normalizeDegrees(orientation)
+        orientationDeg = normalized
+        orientationRad = Math.toRadians(normalized.toDouble()).toFloat()
+        if (lastTimestamp != null) {
+            this.lastTimestamp = lastTimestamp
+        }
+    }
+
+    fun reset() {
+        orientationRad = 0f
+        orientationDeg = 0f
+        lastTimestamp = null
+    }
+
+    fun currentOrientation(): Float = orientationDeg
+
+    fun lastSampleTimestamp(): Instant? = lastTimestamp
+
+    companion object {
+        fun normalizeRadians(angle: Float): Float {
+            val twoPi = (Math.PI * 2.0).toFloat()
+            var value = angle % twoPi
+            if (value >= Math.PI) value -= twoPi
+            if (value < -Math.PI) value += twoPi
+            return value
+        }
+
+        fun normalizeDegrees(angle: Float): Float {
+            var value = angle % 360f
+            if (value >= 180f) value -= 360f
+            if (value < -180f) value += 360f
+            return value
+        }
+
+        fun withOrientation(rotations: List<Rotation>): List<Rotation> {
+            val tracker = GyroscopeOrientationTracker()
+            var currentOrientation = 0f
+            var previousTimestamp: Instant? = null
+            return rotations.map { rotation ->
+                val stored = rotation.gyroscopeOrientation?.let { normalizeDegrees(it) }
+                val orientation = when {
+                    stored != null -> {
+                        tracker.apply(stored, rotation.gyroscope.lastOrNull()?.timestamp ?: previousTimestamp)
+                        stored
+                    }
+                    rotation.gyroscope.isEmpty() -> currentOrientation
+                    else -> {
+                        val start = previousTimestamp ?: rotation.gyroscope.first().timestamp
+                        tracker.integrate(rotation.gyroscope, start)
+                    }
+                }
+                currentOrientation = orientation
+                previousTimestamp = rotation.gyroscope.lastOrNull()?.timestamp ?: previousTimestamp
+                rotation.copy(gyroscopeOrientation = orientation)
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarPlot.kt
@@ -34,6 +34,7 @@ fun LidarPlot(
     gradientMin: Int = 100,
     floorPlan: List<List<Pair<Float, Float>>> = emptyList(),
     measurementOrientation: Float = 0f,
+    gyroscopeRotation: Float = 0f,
     planScale: Float = 1f,
     userPosition: Pair<Float, Float>? = null,
     occupancyGrid: OccupancyGrid? = null,
@@ -44,7 +45,7 @@ fun LidarPlot(
     Canvas(modifier = modifier) {
         val points = measurements.map { m ->
             var (x, y) = m.toPoint()
-            val total = rotation.toFloat() + measurementOrientation
+            val total = rotation.toFloat() + measurementOrientation + gyroscopeRotation
             if (total != 0f) {
                 val angleRad = Math.toRadians(total.toDouble())
                 val cos = kotlin.math.cos(angleRad).toFloat()
@@ -60,7 +61,7 @@ fun LidarPlot(
         val segments = lines.map { line ->
             var (sx, sy) = line.start
             var (ex, ey) = line.end
-            val total = rotation.toFloat() + measurementOrientation
+            val total = rotation.toFloat() + measurementOrientation + gyroscopeRotation
             if (total != 0f) {
                 val angleRad = Math.toRadians(total.toDouble())
                 val cos = kotlin.math.cos(angleRad).toFloat()

--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
@@ -17,4 +17,8 @@ data class Rotation(
     val measurements: List<LidarMeasurement>,
     val start: Instant = Clock.System.now(),
     val gyroscope: List<GyroscopeMeasurement> = emptyList(),
+    /**
+     * Absolute device orientation in degrees after this rotation.
+     */
+    val gyroscopeOrientation: Float? = null,
 )

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -72,6 +72,8 @@ fun LidarScreen(vm: LidarViewModel) {
     val lengthPercentile by vm.lineFilterLengthPercentile.collectAsState()
     val inlierPercentile by vm.lineFilterInlierPercentile.collectAsState()
     val gyroscopeState by vm.gyroscopeState.collectAsState()
+    val gyroscopeRotationEnabled by vm.gyroscopeRotationEnabled.collectAsState()
+    val gyroscopeRotation by vm.gyroscopeRotation.collectAsState()
     val configuration = LocalConfiguration.current
     val context = LocalContext.current
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -121,6 +123,7 @@ fun LidarScreen(vm: LidarViewModel) {
     val filteredPct by vm.filteredPercentage.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+    val gyroStatusSuffix = if (gyroscopeRotationEnabled) "" else " (off)"
 
     if (isPortrait) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -155,6 +158,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     gradientMin = gradientMin.toInt(),
                     floorPlan = floorPlan,
                     measurementOrientation = measurementOrientation,
+                    gyroscopeRotation = if (gyroscopeRotationEnabled) gyroscopeRotation else 0f,
                     planScale = planScale,
                     userPosition = userPosition,
                     occupancyGrid = occupancyGrid,
@@ -197,6 +201,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     Text("Pose score: $poseScore")
                     Text("Pose avg50: ${"%.1f".format(poseAvg)}")
                     Text("Orientation: ${"%.1f".format(measurementOrientation)}°")
+                    Text("Gyro rotation: ${"%.1f".format(gyroscopeRotation)}°$gyroStatusSuffix")
                     Text("Scale: ${"%.2f".format(planScale)}")
                 }
             }
@@ -263,6 +268,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     gradientMin = gradientMin.toInt(),
                     floorPlan = floorPlan,
                     measurementOrientation = measurementOrientation,
+                    gyroscopeRotation = if (gyroscopeRotationEnabled) gyroscopeRotation else 0f,
                     planScale = planScale,
                     userPosition = userPosition,
                     occupancyGrid = occupancyGrid,
@@ -359,10 +365,11 @@ fun LidarScreen(vm: LidarViewModel) {
                     }
                     Column(modifier = Modifier.weight(1f)) {
                         Text("Pose time ms: $poseMs")
-                        Text("Pose score: $poseScore")
-                        Text("Pose avg50: ${"%.1f".format(poseAvg)}")
-                        Text("Orientation: ${"%.1f".format(measurementOrientation)}°")
-                        Text("Scale: ${"%.2f".format(planScale)}")
+                    Text("Pose score: $poseScore")
+                    Text("Pose avg50: ${"%.1f".format(poseAvg)}")
+                    Text("Orientation: ${"%.1f".format(measurementOrientation)}°")
+                    Text("Gyro rotation: ${"%.1f".format(gyroscopeRotation)}°$gyroStatusSuffix")
+                    Text("Scale: ${"%.2f".format(planScale)}")
                     }
                 }
                 if (showLogs) {

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -79,6 +79,7 @@ fun SettingsPanel(
     val lineAlgorithm by vm.lineAlgorithm.collectAsState()
     val showGrid by vm.showOccupancyGrid.collectAsState()
     val gyroscopeRate by vm.gyroscopeRate.collectAsState()
+    val gyroscopeRotationEnabled by vm.gyroscopeRotationEnabled.collectAsState()
     val gridCellSize by vm.gridCellSize.collectAsState()
     val useLastPose by vm.useLastPose.collectAsState()
     val poseAlgorithm by vm.poseAlgorithm.collectAsState()
@@ -129,6 +130,13 @@ fun SettingsPanel(
             valueRange = GyroscopeReader.MIN_RATE_HZ.toFloat()..400f,
             onReset = { vm.resetGyroscopeRate() }
         )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = gyroscopeRotationEnabled,
+                onCheckedChange = { vm.setGyroscopeRotationEnabled(it) }
+            )
+            Text("Rotate measurements")
+        }
         Divider()
         Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -48,4 +48,5 @@ data class LidarSettings(
     val particleCount: Int = LidarViewModel.DEFAULT_PARTICLE_COUNT,
     val particleIterations: Int = LidarViewModel.DEFAULT_PARTICLE_ITERATIONS,
     val gyroscopeRate: Int = GyroscopeReader.DEFAULT_RATE_HZ,
+    val gyroscopeRotationEnabled: Boolean = LidarViewModel.DEFAULT_GYROSCOPE_ROTATION_ENABLED,
 )

--- a/app/src/test/kotlin/com/koriit/positioner/android/gyro/GyroscopeOrientationTrackerTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/gyro/GyroscopeOrientationTrackerTest.kt
@@ -1,0 +1,78 @@
+package com.koriit.positioner.android.gyro
+
+import com.koriit.positioner.android.lidar.LidarMeasurement
+import com.koriit.positioner.android.recording.Rotation
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class GyroscopeOrientationTrackerTest {
+
+    @Test
+    fun `integrates sequential samples`() {
+        val tracker = GyroscopeOrientationTracker()
+        val base = Instant.parse("2024-01-01T00:00:00Z")
+        val samples = listOf(
+            GyroscopeMeasurement(0f, 0f, 1f, base),
+            GyroscopeMeasurement(0f, 0f, 1f, base + 1.seconds),
+        )
+
+        val orientation = tracker.integrate(samples)
+        assertEquals(57.29578, orientation.toDouble(), 1e-3)
+
+        val negative = tracker.integrate(
+            listOf(
+                GyroscopeMeasurement(0f, 0f, -0.5f, base + 2.seconds)
+            )
+        )
+        assertEquals(28.64789, negative.toDouble(), 1e-3)
+    }
+
+    @Test
+    fun `normalises angles`() {
+        assertEquals(-170.0, GyroscopeOrientationTracker.normalizeDegrees(190f).toDouble(), 0.0)
+        assertEquals(170.0, GyroscopeOrientationTracker.normalizeDegrees(-190f).toDouble(), 0.0)
+
+        val twoPi = (Math.PI * 2).toFloat()
+        assertEquals(0.0, GyroscopeOrientationTracker.normalizeRadians(twoPi).toDouble(), 1e-6)
+        assertEquals(
+            Math.PI - 0.1,
+            GyroscopeOrientationTracker.normalizeRadians(-(Math.PI + 0.1).toFloat()).toDouble(),
+            1e-6
+        )
+    }
+
+    @Test
+    fun `reconstructs orientation for recorded rotations`() {
+        val base = Instant.parse("2024-01-01T00:00:00Z")
+        val rotation1 = Rotation(
+            measurements = listOf(LidarMeasurement(0f, 0, 0)),
+            start = base,
+            gyroscope = listOf(
+                GyroscopeMeasurement(0f, 0f, 0.5f, base),
+                GyroscopeMeasurement(0f, 0f, 0.5f, base + 2.seconds),
+            )
+        )
+        val rotation2 = Rotation(
+            measurements = listOf(LidarMeasurement(0f, 0, 0)),
+            start = base + 3.seconds,
+            gyroscope = emptyList(),
+        )
+        val rotation3 = Rotation(
+            measurements = listOf(LidarMeasurement(0f, 0, 0)),
+            start = base + 4.seconds,
+            gyroscope = listOf(
+                GyroscopeMeasurement(0f, 0f, 1f, base + 4.seconds),
+                GyroscopeMeasurement(0f, 0f, 1f, base + 5.seconds),
+            ),
+            gyroscopeOrientation = 200f,
+        )
+
+        val result = GyroscopeOrientationTracker.withOrientation(listOf(rotation1, rotation2, rotation3))
+
+        assertEquals(57.29578, result[0].gyroscopeOrientation!!.toDouble(), 1e-3)
+        assertEquals(result[0].gyroscopeOrientation, result[1].gyroscopeOrientation)
+        assertEquals(-160.0, result[2].gyroscopeOrientation!!.toDouble(), 1e-3)
+    }
+}

--- a/docs/gyroscope.adoc
+++ b/docs/gyroscope.adoc
@@ -8,3 +8,9 @@ the `HIGH_SAMPLING_RATE_SENSORS` permission which is declared in the manifest.
 All samples collected between two LiDAR rotations are buffered and stored with
 each rotation packet. If the gyroscope is unavailable, disabled or either
 required permission is missing the app continues without IMU data.
+
+When the *Rotate measurements* option is enabled in the gyroscope section of
+the settings screen the app integrates the z-axis angular velocity to estimate
+device heading and rotates the LiDAR scan before rendering it. Negative sensor
+values correspond to turning right, so the plot is rotated to the right to keep
+the environment aligned with the real world orientation.


### PR DESCRIPTION
## Summary
- add a reusable gyroscope orientation tracker and persist the absolute heading with each recorded rotation
- expose a toggle to rotate scans with gyroscope data and display the live heading on the LiDAR screen
- apply the gyroscope heading in the plot renderer and cover the new logic with unit tests

## Testing
- ./gradlew tasks --no-daemon --console=plain
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc07278e58832fa142b92ec351a661