### PR TITLE
Fix measurement filtering toggle and adjust controls

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -205,13 +205,11 @@ fun LidarScreen(vm: LidarViewModel) {
                     Text("Scale: ${"%.2f".format(planScale)}")
                 }
             }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Button(
-                    onClick = { vm.rotate90() },
-                    enabled = floorPlan.isEmpty()
-                ) { Text("Rotate 90°") }
-            }
-            Row(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
                 Button(
                     onClick = {
                         if (recording) {
@@ -221,24 +219,37 @@ fun LidarScreen(vm: LidarViewModel) {
                             recordLauncher.launch("lidar-session-$timestamp.json.gz")
                         }
                     },
-                    enabled = !replaying
+                    enabled = !replaying,
+                    modifier = Modifier.weight(1f)
                 ) {
                     Text(if (recording) "Stop Recording" else "Start Recording")
                 }
-            }
-            Row(modifier = Modifier.fillMaxWidth()) {
                 Button(
                     onClick = { loadLauncher.launch(arrayOf("application/gzip", "application/json")) },
-                    enabled = !recording && !replaying && !loading
+                    enabled = !recording && !replaying && !loading,
+                    modifier = Modifier.weight(1f)
                 ) { Text("Load") }
                 if (replaying) {
-                    Button(onClick = { vm.exitReplay() }) { Text("Exit Replay") }
+                    Button(
+                        onClick = { vm.exitReplay() },
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Exit Replay") }
                 }
             }
-            Row(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = { vm.rotate90() },
+                    enabled = floorPlan.isEmpty(),
+                    modifier = Modifier.weight(1f)
+                ) { Text("Rotate 90°") }
                 Button(
                     onClick = { floorPlanLauncher.launch(arrayOf("application/json")) },
-                    enabled = !loading
+                    enabled = !loading,
+                    modifier = Modifier.weight(1f)
                 ) { Text("Load Floor Plan") }
             }
             if (replaying) {
@@ -312,13 +323,11 @@ fun LidarScreen(vm: LidarViewModel) {
                         scrollable = false,
                     )
                 }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Button(
-                        onClick = { vm.rotate90() },
-                        enabled = floorPlan.isEmpty()
-                    ) { Text("Rotate 90°") }
-                }
-                Row(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Button(
                         onClick = {
                             if (recording) {
@@ -328,29 +337,42 @@ fun LidarScreen(vm: LidarViewModel) {
                                 recordLauncher.launch("lidar-session-$timestamp.json.gz")
                             }
                         },
-                        enabled = !replaying
+                        enabled = !replaying,
+                        modifier = Modifier.weight(1f)
                     ) {
                         Text(if (recording) "Stop Recording" else "Start Recording")
                     }
+                    Button(
+                        onClick = { loadLauncher.launch(arrayOf("application/gzip", "application/json")) },
+                        enabled = !recording && !replaying && !loading,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Load") }
+                    if (replaying) {
+                        Button(
+                            onClick = { vm.exitReplay() },
+                            modifier = Modifier.weight(1f)
+                        ) { Text("Exit Replay") }
+                    }
                 }
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Button(
-                    onClick = { loadLauncher.launch(arrayOf("application/gzip", "application/json")) },
-                    enabled = !recording && !replaying && !loading
-                ) { Text("Load") }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Button(
+                        onClick = { vm.rotate90() },
+                        enabled = floorPlan.isEmpty(),
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Rotate 90°") }
+                    Button(
+                        onClick = { floorPlanLauncher.launch(arrayOf("application/json")) },
+                        enabled = !loading,
+                        modifier = Modifier.weight(1f)
+                    ) { Text("Load Floor Plan") }
+                }
                 if (replaying) {
-                    Button(onClick = { vm.exitReplay() }) { Text("Exit Replay") }
+                    ReplayControls(vm)
                 }
-            }
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Button(
-                    onClick = { floorPlanLauncher.launch(arrayOf("application/json")) },
-                    enabled = !loading
-                ) { Text("Load Floor Plan") }
-            }
-            if (replaying) {
-                ReplayControls(vm)
-            }
                 Row(modifier = Modifier.fillMaxWidth()) {
                     Column(modifier = Modifier.weight(1f)) {
                         Text("Measurements/s: $mps")

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/SettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.unit.dp
 import com.koriit.positioner.android.localization.PoseAlgorithm
 import com.koriit.positioner.android.lidar.LineAlgorithm
@@ -59,6 +60,7 @@ fun SettingsPanel(
     val confidence by vm.confidenceThreshold.collectAsState()
     val gradientMin by vm.gradientMin.collectAsState()
     val minDistance by vm.minDistance.collectAsState()
+    val isolationFilterEnabled by vm.isolationFilterEnabled.collectAsState()
     val isolationDistance by vm.isolationDistance.collectAsState()
     val isolationMinNeighbours by vm.isolationMinNeighbours.collectAsState()
     val detectLines by vm.detectLines.collectAsState()
@@ -166,19 +168,35 @@ fun SettingsPanel(
             valueRange = 0f..2f,
             onReset = { vm.resetMinDistance() }
         )
-        Text("Isolation distance: ${"%.2f".format(isolationDistance)} m")
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = isolationFilterEnabled,
+                onCheckedChange = { vm.isolationFilterEnabled.value = it }
+            )
+            Text("Remove isolated points")
+        }
+        val isolationAlpha = if (isolationFilterEnabled) 1f else 0.6f
+        Text(
+            "Isolation distance: ${"%.2f".format(isolationDistance)} m",
+            modifier = Modifier.alpha(isolationAlpha)
+        )
         SliderWithActions(
             value = isolationDistance,
             onValueChange = { vm.isolationDistance.value = it },
             valueRange = 0f..5f,
-            onReset = { vm.resetIsolationDistance() }
+            onReset = { vm.resetIsolationDistance() },
+            enabled = isolationFilterEnabled,
         )
-        Text("Isolation neighbours: $isolationMinNeighbours")
+        Text(
+            "Isolation neighbours: $isolationMinNeighbours",
+            modifier = Modifier.alpha(isolationAlpha)
+        )
         SliderWithActions(
             value = isolationMinNeighbours.toFloat(),
             onValueChange = { vm.isolationMinNeighbours.value = it.toInt() },
             valueRange = 0f..10f,
-            onReset = { vm.resetIsolationMinNeighbours() }
+            onReset = { vm.resetIsolationMinNeighbours() },
+            enabled = isolationFilterEnabled,
         )
         Divider()
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/viewmodel/LidarSettings.kt
@@ -18,6 +18,7 @@ data class LidarSettings(
     val confidenceThreshold: Float = LidarViewModel.DEFAULT_CONFIDENCE_THRESHOLD,
     val gradientMin: Float = LidarViewModel.DEFAULT_GRADIENT_MIN,
     val minDistance: Float = LidarViewModel.DEFAULT_MIN_DISTANCE,
+    val isolationFilterEnabled: Boolean = LidarViewModel.DEFAULT_ISOLATION_FILTER_ENABLED,
     val isolationDistance: Float = LidarViewModel.DEFAULT_ISOLATION_DISTANCE,
     val isolationMinNeighbours: Int = LidarViewModel.DEFAULT_MIN_NEIGHBOURS,
     val detectLines: Boolean = false,


### PR DESCRIPTION
## Summary
- ensure the Filter pose input toggle actually switches between raw and filtered measurements and gate isolation filtering with a new setting
- expose an isolation filtering checkbox in the settings UI and disable the related sliders when off
- place recording/load and rotate/load floor plan actions on shared rows for better layout while persisting the new setting

## Testing
- ./gradlew tasks --no-daemon --console=plain > /tmp/gradle_tasks.txt
- tail -n 20 /tmp/gradle_tasks.txt
- ./gradlew test --no-daemon --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68ce70cbe078832f89f37aa9df89ecfc