### PR TITLE
Normalize LIDAR parser output angles

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarParser.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/lidar/LidarParser.kt
@@ -1,6 +1,5 @@
 package com.koriit.positioner.android.lidar
 
-import com.koriit.positioner.android.logging.AppLog
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -12,6 +11,14 @@ class LidarParser {
         private const val TAG = "LidarParser"
         private const val PACKET_LENGTH = 47
         private const val MEASUREMENT_LENGTH = 12
+
+        private fun normalizeAngle(angle: Float): Float {
+            var normalized = angle % 360f
+            if (normalized < 0f) {
+                normalized += 360f
+            }
+            return normalized
+        }
     }
 
     /**
@@ -42,9 +49,10 @@ class LidarParser {
 //        AppLog.d(TAG, "startAngle=$startAngle stopAngle=$stopAngle")
         val result = mutableListOf<LidarMeasurement>()
         for (i in 0 until MEASUREMENT_LENGTH) {
-            val angle = startAngle + step * i
+            val angle = normalizeAngle(startAngle + step * i)
             result.add(LidarMeasurement(angle, distance[i], confidence[i]))
         }
         return result
     }
+
 }

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/LidarParserTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/LidarParserTest.kt
@@ -1,0 +1,33 @@
+package com.koriit.positioner.android.lidar
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LidarParserTest {
+
+    @Test
+    fun `normalizes angles that wrap past 360 degrees`() {
+        val packet = ByteBuffer.allocate(47).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put(0x54.toByte())
+            put(0x2C.toByte())
+            putShort(0) // speed
+            putShort((35000).toShort()) // start angle = 350 degrees
+            repeat(12) { index ->
+                putShort((1000 + index).toShort())
+                put(index.toByte())
+            }
+            putShort((1000).toShort()) // stop angle = 10 degrees
+            putShort(0) // timestamp
+            put(0) // crc
+        }.array()
+
+        val measurements = LidarParser().parse(packet)
+
+        assertEquals(12, measurements.size)
+        assertEquals(10f, measurements.last().angle, 1e-3f)
+        assertTrue(measurements.all { it.angle >= 0f && it.angle < 360f })
+    }
+}


### PR DESCRIPTION
## Summary
- normalize computed measurement angles in `LidarParser` so they stay within 0-360 degrees
- add a regression test that exercises angle wrapping across the 360-degree boundary

## Testing
- ./gradlew tasks --no-daemon --console=plain
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce9e6daff0832f95e8042dfa3de896