### PR TITLE
Add CRC validation and surface corrupted packet counts

### DIFF
--- a/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/recording/Rotation.kt
@@ -21,4 +21,8 @@ data class Rotation(
      * Absolute device orientation in degrees after this rotation.
      */
     val gyroscopeOrientation: Float? = null,
+    /**
+     * Packets discarded due to CRC errors while collecting this rotation.
+     */
+    val corruptedPackets: Int = 0,
 )

--- a/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
+++ b/app/src/main/kotlin/com/koriit/positioner/android/ui/LidarScreen.kt
@@ -121,6 +121,7 @@ fun LidarScreen(vm: LidarViewModel) {
     val poseAvg by vm.poseScoreAverage.collectAsState()
     val filteredCount by vm.filteredMeasurements.collectAsState()
     val filteredPct by vm.filteredPercentage.collectAsState()
+    val corruptedPackets by vm.corruptedPackets.collectAsState()
 
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
     val gyroStatusSuffix = if (gyroscopeRotationEnabled) "" else " (off)"
@@ -190,6 +191,7 @@ fun LidarScreen(vm: LidarViewModel) {
                     Text("Rotations/s: ${"%.2f".format(rps)}")
                     Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
                     Text("Filtered: $filteredCount (${"%.1f".format(filteredPct)}%)")
+                    Text("Corrupted packets: $corruptedPackets")
                     Text("Lines: ${lineFeatures.size}")
                     if (lineFilterEnabled) {
                         Text("Len P${lengthPercentile.toInt()}: ${"%.2f".format(lineLengthPx)} m")
@@ -379,6 +381,7 @@ fun LidarScreen(vm: LidarViewModel) {
                         Text("Rotations/s: ${"%.2f".format(rps)}")
                         Text("Pose combos/s: ${"%.0f".format(poseCombos)}")
                         Text("Filtered: $filteredCount (${"%.1f".format(filteredPct)}%)")
+                        Text("Corrupted packets: $corruptedPackets")
                         Text("Lines: ${lineFeatures.size}")
                         if (lineFilterEnabled) {
                             Text("Len P${lengthPercentile.toInt()}: ${"%.2f".format(lineLengthPx)} m")

--- a/app/src/test/kotlin/com/koriit/positioner/android/lidar/LidarParserTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/lidar/LidarParserTest.kt
@@ -21,13 +21,56 @@ class LidarParserTest {
             }
             putShort((1000).toShort()) // stop angle = 10 degrees
             putShort(0) // timestamp
-            put(0) // crc
-        }.array()
+            put(0) // crc placeholder
+        }.array().apply { this[lastIndex] = computeCrc(this).toByte() }
 
         val measurements = LidarParser().parse(packet)
 
         assertEquals(12, measurements.size)
         assertEquals(10f, measurements.last().angle, 1e-3f)
         assertTrue(measurements.all { it.angle >= 0f && it.angle < 360f })
+    }
+
+    @Test
+    fun `returns empty list when crc is invalid`() {
+        val packet = ByteBuffer.allocate(47).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put(0x54.toByte())
+            put(0x2C.toByte())
+            putShort(0)
+            putShort((0).toShort())
+            repeat(12) {
+                putShort(100.toShort())
+                put(0)
+            }
+            putShort((1000).toShort())
+            putShort(0)
+            put(0)
+        }.array().apply { this[lastIndex] = computeCrc(this).toByte() }
+
+        val parser = LidarParser()
+        val valid = parser.parse(packet)
+        assertEquals(12, valid.size)
+
+        val corrupted = packet.clone()
+        corrupted[corrupted.lastIndex] = (corrupted.last().toInt() xor 0xFF).toByte()
+        val result = parser.parse(corrupted)
+
+        assertTrue(result.isEmpty())
+    }
+
+    private fun computeCrc(data: ByteArray): Int {
+        var crc = 0
+        for (i in 0 until data.lastIndex) {
+            var value = (crc xor (data[i].toInt() and 0xFF)) and 0xFF
+            repeat(8) {
+                value = if ((value and 0x80) != 0) {
+                    ((value shl 1) xor 0x4D)
+                } else {
+                    value shl 1
+                }
+            }
+            crc = value and 0xFF
+        }
+        return crc
     }
 }

--- a/app/src/test/kotlin/com/koriit/positioner/android/recording/SessionReaderTest.kt
+++ b/app/src/test/kotlin/com/koriit/positioner/android/recording/SessionReaderTest.kt
@@ -17,7 +17,8 @@ class SessionReaderTest {
             measurements = listOf(
                 LidarMeasurement(10f, 100, 255),
                 LidarMeasurement(20f, 100, 255)
-            )
+            ),
+            corruptedPackets = 3,
         )
         val json = Json.encodeToString(rotation)
         val file = File.createTempFile("rotation", ".json.gz")
@@ -30,6 +31,7 @@ class SessionReaderTest {
             val result = SessionReader.read(stream)
             assertEquals(1, result.size)
             assertEquals(2, result.first().measurements.size)
+            assertEquals(3, result.first().corruptedPackets)
         }
     }
 
@@ -51,6 +53,8 @@ class SessionReaderTest {
             assertEquals(2, result.size)
             assertEquals(2, result.first().measurements.size)
             assertEquals(1, result.last().measurements.size)
+            assertEquals(0, result.first().corruptedPackets)
+            assertEquals(0, result.last().corruptedPackets)
         }
     }
 }


### PR DESCRIPTION
## Summary
- validate lidar packets using the documented CRC-8 polynomial and drop corrupted packets in the parser
- propagate a new lidar rotation batch type that reports corrupted packet counts, persist them in recordings, and expose them through the view model
- surface corrupted packet statistics in the UI and update session reader and parser tests for the new behaviour

## Testing
- ./gradlew --console=plain tasks --no-daemon
- ./gradlew --console=plain test --no-daemon


------
https://chatgpt.com/codex/tasks/task_e_68cea8b77bdc832f848875e7c7a8fd53